### PR TITLE
feat(auth): Next.js Proxy session refresh and route guards

### DIFF
--- a/lib/supabase/proxy.test.ts
+++ b/lib/supabase/proxy.test.ts
@@ -1,0 +1,98 @@
+import { proxy } from '@/proxy';
+import type { User } from '@supabase/supabase-js';
+import { NextRequest, NextResponse } from 'next/server';
+import { describe, expect, it, vi } from 'vitest';
+import { updateSession } from './proxy';
+
+vi.mock('@/lib/supabase/proxy', () => ({
+  updateSession: vi.fn(),
+}));
+
+describe('proxy route guards', () => {
+  it('redirects unauthenticated user accessing protected route /dashboard to /login?redirectTo=/dashboard', async () => {
+    const mockResponse = NextResponse.next();
+    vi.mocked(updateSession).mockResolvedValue({
+      supabaseResponse: mockResponse,
+      user: null,
+    });
+
+    const request = new NextRequest('http://localhost:3000/dashboard');
+    const response = await proxy(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3000/login?redirectTo=%2Fdashboard',
+    );
+  });
+
+  it('redirects unauthenticated user accessing sub-path of protected route /learn/123', async () => {
+    const mockResponse = NextResponse.next();
+    vi.mocked(updateSession).mockResolvedValue({
+      supabaseResponse: mockResponse,
+      user: null,
+    });
+
+    const request = new NextRequest('http://localhost:3000/learn/123');
+    const response = await proxy(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3000/login?redirectTo=%2Flearn%2F123',
+    );
+  });
+
+  it('redirects authenticated user accessing auth route /login to /dashboard', async () => {
+    const mockResponse = NextResponse.next();
+    const mockUser = { id: 'user-123', email: 'test@example.com' } as User;
+    vi.mocked(updateSession).mockResolvedValue({
+      supabaseResponse: mockResponse,
+      user: mockUser,
+    });
+
+    const request = new NextRequest('http://localhost:3000/login');
+    const response = await proxy(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('http://localhost:3000/dashboard');
+  });
+
+  it('allows unauthenticated user to access auth route /login', async () => {
+    const mockResponse = NextResponse.next();
+    vi.mocked(updateSession).mockResolvedValue({
+      supabaseResponse: mockResponse,
+      user: null,
+    });
+
+    const request = new NextRequest('http://localhost:3000/login');
+    const response = await proxy(request);
+
+    expect(response).toBe(mockResponse);
+  });
+
+  it('allows authenticated user to access protected route /dashboard', async () => {
+    const mockResponse = NextResponse.next();
+    const mockUser = { id: 'user-123', email: 'test@example.com' } as User;
+    vi.mocked(updateSession).mockResolvedValue({
+      supabaseResponse: mockResponse,
+      user: mockUser,
+    });
+
+    const request = new NextRequest('http://localhost:3000/dashboard');
+    const response = await proxy(request);
+
+    expect(response).toBe(mockResponse);
+  });
+
+  it('allows access to public landing page / for any user', async () => {
+    const mockResponse = NextResponse.next();
+    vi.mocked(updateSession).mockResolvedValue({
+      supabaseResponse: mockResponse,
+      user: null,
+    });
+
+    const request = new NextRequest('http://localhost:3000/');
+    const response = await proxy(request);
+
+    expect(response).toBe(mockResponse);
+  });
+});

--- a/lib/supabase/proxy.test.ts
+++ b/lib/supabase/proxy.test.ts
@@ -1,7 +1,7 @@
-import { proxy } from '@/proxy';
 import type { User } from '@supabase/supabase-js';
 import { NextRequest, NextResponse } from 'next/server';
 import { describe, expect, it, vi } from 'vitest';
+import { proxy } from '@/proxy';
 import { updateSession } from './proxy';
 
 vi.mock('@/lib/supabase/proxy', () => ({

--- a/lib/supabase/proxy.ts
+++ b/lib/supabase/proxy.ts
@@ -1,0 +1,51 @@
+import { createServerClient } from '@supabase/ssr';
+import { type NextRequest, NextResponse } from 'next/server';
+
+/**
+ * Refreshes the user's Supabase Auth session token and updates request/response cookies.
+ * MUST be called by the root Next.js proxy on every matched request.
+ *
+ * @param request - Incoming NextRequest from Next.js proxy
+ * @returns Object containing the modified NextResponse (with updated cookies) and authenticated User (if valid)
+ */
+export async function updateSession(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({
+    request,
+  });
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error(
+      'Missing Supabase environment variables: NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY',
+    );
+  }
+
+  const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        for (const { name, value } of cookiesToSet) {
+          request.cookies.set(name, value);
+        }
+        supabaseResponse = NextResponse.next({
+          request,
+        });
+        for (const { name, value, options } of cookiesToSet) {
+          supabaseResponse.cookies.set(name, value, options);
+        }
+      },
+    },
+  });
+
+  // IMPORTANT: Do NOT insert business logic between createServerClient and getUser().
+  // Using getUser() instead of getSession() ensures cryptographically secure JWT verification on the server.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  return { supabaseResponse, user };
+}

--- a/lib/supabase/proxy.ts
+++ b/lib/supabase/proxy.ts
@@ -1,4 +1,4 @@
-import { createServerClient } from '@supabase/ssr';
+import { type CookieOptions, createServerClient } from '@supabase/ssr';
 import { type NextRequest, NextResponse } from 'next/server';
 
 /**
@@ -27,7 +27,7 @@ export async function updateSession(request: NextRequest) {
       getAll() {
         return request.cookies.getAll();
       },
-      setAll(cookiesToSet) {
+      setAll(cookiesToSet: { name: string; value: string; options: CookieOptions }[]) {
         for (const { name, value } of cookiesToSet) {
           request.cookies.set(name, value);
         }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,6 @@
+import { proxy } from './proxy';
+export { config } from './proxy';
+
+export function middleware(request: Parameters<typeof proxy>[0]) {
+  return proxy(request);
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,5 @@
 import { proxy } from './proxy';
+
 export { config } from './proxy';
 
 export function middleware(request: Parameters<typeof proxy>[0]) {

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,5 +1,5 @@
-import { updateSession } from '@/lib/supabase/proxy';
 import { type NextRequest, NextResponse } from 'next/server';
+import { updateSession } from '@/lib/supabase/proxy';
 
 const PROTECTED_ROUTES = ['/dashboard', '/learn', '/review', '/settings'];
 const AUTH_ROUTES = ['/login', '/signup', '/forgot-password', '/reset-password'];

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,53 @@
+import { updateSession } from '@/lib/supabase/proxy';
+import { type NextRequest, NextResponse } from 'next/server';
+
+const PROTECTED_ROUTES = ['/dashboard', '/learn', '/review', '/settings'];
+const AUTH_ROUTES = ['/login', '/signup', '/forgot-password', '/reset-password'];
+
+/**
+ * Root Next.js Proxy handler for session refresh and route guarding.
+ */
+export async function proxy(request: NextRequest) {
+  const { supabaseResponse, user } = await updateSession(request);
+  const { pathname } = request.nextUrl;
+
+  // Check if current route matches protected paths or sub-paths
+  const isProtectedRoute = PROTECTED_ROUTES.some(
+    (route) => pathname === route || pathname.startsWith(`${route}/`),
+  );
+
+  // Check if current route matches auth paths or sub-paths
+  const isAuthRoute = AUTH_ROUTES.some(
+    (route) => pathname === route || pathname.startsWith(`${route}/`),
+  );
+
+  // Guard 1: Redirect unauthenticated users attempting to access protected routes
+  if (isProtectedRoute && !user) {
+    const loginUrl = request.nextUrl.clone();
+    loginUrl.pathname = '/login';
+    loginUrl.searchParams.set('redirectTo', pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  // Guard 2: Redirect authenticated users attempting to access auth routes
+  if (isAuthRoute && user) {
+    const dashboardUrl = request.nextUrl.clone();
+    dashboardUrl.pathname = '/dashboard';
+    return NextResponse.redirect(dashboardUrl);
+  }
+
+  return supabaseResponse;
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except:
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     * - Media/asset files (.svg, .png, .jpg, .jpeg, .gif, .webp)
+     */
+    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+  ],
+};

--- a/specs/plan-index.md
+++ b/specs/plan-index.md
@@ -7,12 +7,10 @@ This directory contains technical implementation plans for feature development, 
 ## Index of Epics & Plans
 
 - **[Epic 001: Basic Email & Password Authentication](epics/001-email-password-auth.md)**
-  - Status: Specified / Ready for Implementation
+  - Status: In Progress
   - Provider: Supabase Auth (`@supabase/ssr`) with Drizzle ORM Profile linkage
   - **[Plan 001: Supabase SSR Clients & Drizzle Profiles Schema](plans/001-supabase-ssr-drizzle-schema.md)** — Completed ([PR #46](https://github.com/69420pm/ai-learning-support-test/pull/46))
-  - **[Plan 002: Next.js Proxy Session Refresh & Protected Route Guards](plans/002-proxy-session-refresh-route-guards.md)**
+  - **[Plan 002: Next.js Proxy Session Refresh & Protected Route Guards](plans/002-proxy-session-refresh-route-guards.md)** — In Review ([PR #47](https://github.com/69420pm/ai-learning-support-test/pull/47))
   - **[Plan 003: Auth Server Actions & Auth Callback Route](plans/003-auth-server-actions-callback.md)**
   - **[Plan 004: Auth UI Components & Pages](plans/004-auth-ui-components-pages.md)**
   - **[Plan 005: Header User Navigation Dropdown & Playwright E2E Auth Test Suite](plans/005-user-nav-e2e-tests.md)**
-
-


### PR DESCRIPTION
## Summary

Implements plan: `specs/plans/002-proxy-session-refresh-route-guards.md`

Establishes the global Next.js Proxy session refresh mechanism using `@supabase/ssr` and enforces protected route guards (`/dashboard`, `/learn`, `/review`, `/settings`) and auth route redirects (`/login`, `/signup`, `/forgot-password`, `/reset-password`).

## Changes

- Implemented `updateSession(request: NextRequest)` in `lib/supabase/proxy.ts` using `@supabase/ssr`.
- Implemented global Next.js proxy in `proxy.ts` and `middleware.ts` for route guarding and session cookie synchronization.
- Added comprehensive Vitest unit tests for proxy route guards in `lib/supabase/proxy.test.ts`.

## Definition of Done

- [x] `@/lib/supabase/proxy.ts` exports `updateSession(request: NextRequest)` which creates a `@supabase/ssr` client with request cookie getters and response cookie setters.
- [x] `updateSession` executes `supabase.auth.getUser()` to safely revalidate the JWT token and refresh session cookies.
- [x] Root `proxy.ts` invokes `updateSession` on all non-static requests.
- [x] Requests to protected routes (`/dashboard`, `/learn`, `/review`, `/settings` and sub-paths) by unauthenticated users are redirected to `/login?redirectTo=<path>`.
- [x] Requests to auth routes (`/login`, `/signup`, `/forgot-password`, `/reset-password`) by authenticated users are redirected to `/dashboard`.
- [x] Static assets (`_next/static`, `_next/image`, `favicon.ico`, images) bypass proxy evaluation via matcher configuration.
- [x] Project checks (`pnpm check`, `pnpm lint`) compile cleanly with zero errors.

## Verification

- [x] `pnpm check` passes (lint + typecheck + test)
- [x] Runtime verified via next-dev-loop (0 compilation/runtime errors, tested HTTP redirects on protected and auth routes)
- [x] Unit tests written and passing (`lib/supabase/proxy.test.ts`, 6 tests passing)