### PR TITLE
feat(ai): multi-LLM provider resolution and streaming API controller

### DIFF
--- a/app/api/chat/route.test.ts
+++ b/app/api/chat/route.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DELETE, POST } from './route';
+
+// Mock dependencies
+const mockGetUser = vi.fn();
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn().mockImplementation(async () => ({
+    auth: {
+      getUser: mockGetUser,
+    },
+  })),
+}));
+
+const mockSaveChat = vi.fn();
+const mockGetChatById = vi.fn();
+const mockSaveMessages = vi.fn();
+const mockGetMessagesByChatId = vi.fn();
+const mockUpdateChatTitleById = vi.fn();
+const mockDeleteChatById = vi.fn();
+
+vi.mock('@/lib/db/queries/chat', () => ({
+  saveChat: (...args: unknown[]) => mockSaveChat(...args),
+  getChatById: (...args: unknown[]) => mockGetChatById(...args),
+  saveMessages: (...args: unknown[]) => mockSaveMessages(...args),
+  getMessagesByChatId: (...args: unknown[]) => mockGetMessagesByChatId(...args),
+  updateChatTitleById: (...args: unknown[]) => mockUpdateChatTitleById(...args),
+  deleteChatById: (...args: unknown[]) => mockDeleteChatById(...args),
+}));
+
+// Mock AI SDK language model and generateText
+const mockLanguageModel = {
+  specificationVersion: 'v2',
+  provider: 'mock',
+  modelId: 'mock-model',
+  defaultObjectGenerationMode: 'tool',
+  doGenerate: vi.fn().mockResolvedValue({
+    content: [{ type: 'text', text: 'Mocked Generated Title' }],
+    finishReason: 'stop',
+    usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+    warnings: [],
+  }),
+  doStream: vi.fn().mockResolvedValue({
+    stream: new ReadableStream({
+      start(controller) {
+        controller.enqueue({ type: 'text-start', id: 't1' });
+        controller.enqueue({ type: 'text-delta', id: 't1', delta: 'Hello world' });
+        controller.enqueue({ type: 'text-end', id: 't1' });
+        controller.enqueue({
+          type: 'finish',
+          finishReason: 'stop',
+          usage: { inputTokens: 5, outputTokens: 5 },
+        });
+        controller.close();
+      },
+    }),
+  }),
+};
+
+vi.mock('@/lib/ai/providers', () => ({
+  getLanguageModel: vi.fn().mockImplementation(() => mockLanguageModel),
+  getTitleModel: vi.fn().mockImplementation(() => mockLanguageModel),
+}));
+
+describe('Chat API Handler (/api/chat)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('POST /api/chat', () => {
+    it('returns 401 Unauthorized when session is unauthenticated', async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+
+      const request = new Request('http://localhost:3000/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          id: '550e8400-e29b-41d4-a716-446655440000',
+          message: { id: 'msg-1', role: 'user', parts: [{ type: 'text', text: 'Hi' }] },
+        }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(401);
+      const json = await response.json();
+      expect(json.code).toBe('unauthorized:chat');
+    });
+
+    it('returns 400 Bad Request on invalid body schema', async () => {
+      const request = new Request('http://localhost:3000/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          id: 'not-a-uuid',
+        }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.code).toBe('bad_request:api');
+    });
+
+    it('creates chat and streams response when authenticated', async () => {
+      const testUser = { id: 'user-uuid-123', email: 'test@example.com' };
+      mockGetUser.mockResolvedValueOnce({ data: { user: testUser }, error: null });
+      mockGetChatById.mockResolvedValueOnce(null); // Chat does not exist yet
+      mockSaveChat.mockResolvedValueOnce({
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        userId: testUser.id,
+        title: 'New chat',
+      });
+
+      const request = new Request('http://localhost:3000/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          id: '550e8400-e29b-41d4-a716-446655440000',
+          message: {
+            id: 'msg-user-1',
+            role: 'user',
+            parts: [{ type: 'text', text: 'Tell me a joke' }],
+          },
+          provider: 'google',
+        }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      expect(response.headers.get('content-type')).toContain('text/event-stream');
+
+      // Consume stream to trigger execution & onEnd callbacks
+      const reader = response.body?.getReader();
+      if (reader) {
+        let done = false;
+        while (!done) {
+          const res = await reader.read();
+          done = res.done;
+        }
+      }
+
+      expect(mockSaveChat).toHaveBeenCalledWith({
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        title: 'New chat',
+        userId: testUser.id,
+      });
+
+      expect(mockSaveMessages).toHaveBeenCalledWith({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'msg-user-1',
+            chatId: '550e8400-e29b-41d4-a716-446655440000',
+            role: 'user',
+          }),
+        ]),
+      });
+    });
+
+    it('returns 403 Forbidden if user tries to post to another user chat', async () => {
+      const testUser = { id: 'user-uuid-123', email: 'test@example.com' };
+      mockGetUser.mockResolvedValueOnce({ data: { user: testUser }, error: null });
+      mockGetChatById.mockResolvedValueOnce({
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        userId: 'other-user-id',
+        title: 'Secret Chat',
+      });
+
+      const request = new Request('http://localhost:3000/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          id: '550e8400-e29b-41d4-a716-446655440000',
+          message: { id: 'msg-user-1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] },
+        }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(403);
+      const json = await response.json();
+      expect(json.code).toBe('forbidden:chat');
+    });
+  });
+
+  describe('DELETE /api/chat', () => {
+    it('returns 401 Unauthorized when unauthenticated', async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+
+      const request = new Request(
+        'http://localhost:3000/api/chat?id=550e8400-e29b-41d4-a716-446655440000',
+        {
+          method: 'DELETE',
+        },
+      );
+
+      const response = await DELETE(request);
+      expect(response.status).toBe(401);
+    });
+
+    it('deletes chat when authenticated user owns it', async () => {
+      const testUser = { id: 'user-uuid-123' };
+      mockGetUser.mockResolvedValueOnce({ data: { user: testUser }, error: null });
+      mockGetChatById.mockResolvedValueOnce({
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        userId: testUser.id,
+      });
+      mockDeleteChatById.mockResolvedValueOnce({
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        userId: testUser.id,
+      });
+
+      const request = new Request(
+        'http://localhost:3000/api/chat?id=550e8400-e29b-41d4-a716-446655440000',
+        {
+          method: 'DELETE',
+        },
+      );
+
+      const response = await DELETE(request);
+      expect(response.status).toBe(200);
+      expect(mockDeleteChatById).toHaveBeenCalledWith({
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        userId: testUser.id,
+      });
+    });
+  });
+});

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,209 @@
+import {
+  convertToModelMessages,
+  createUIMessageStream,
+  createUIMessageStreamResponse,
+  generateText,
+  streamText,
+  toUIMessageStream,
+} from 'ai';
+import { systemPrompt, titlePrompt } from '@/lib/ai/prompts';
+import { getLanguageModel, getTitleModel, type ProviderName } from '@/lib/ai/providers';
+import {
+  deleteChatById,
+  getChatById,
+  getMessagesByChatId,
+  saveChat,
+  saveMessages,
+  updateChatTitleById,
+} from '@/lib/db/queries/chat';
+import { ChatbotError } from '@/lib/errors';
+import { createClient } from '@/lib/supabase/server';
+import type { ChatMessage } from '@/lib/types';
+import { convertToUIMessages, getTextFromMessage } from '@/lib/utils';
+import { type PostRequestBody, postRequestBodySchema } from './schema';
+
+export const maxDuration = 60;
+
+async function prepareChatState({
+  id,
+  userId,
+  userMessage,
+  provider,
+  apiKey,
+}: {
+  id: string;
+  userId: string;
+  userMessage?: PostRequestBody['message'];
+  provider?: ProviderName;
+  apiKey?: string;
+}) {
+  const chat = await getChatById({ id, userId });
+  let titlePromise: Promise<string> | null = null;
+  let messagesFromDb: Awaited<ReturnType<typeof getMessagesByChatId>> = [];
+
+  if (chat) {
+    if (chat.userId !== userId) {
+      throw new ChatbotError('forbidden:chat');
+    }
+    messagesFromDb = await getMessagesByChatId({ chatId: id });
+  } else {
+    await saveChat({ id, title: 'New chat', userId });
+
+    if (userMessage) {
+      titlePromise = generateText({
+        model: getTitleModel({ provider, apiKey }),
+        instructions: titlePrompt,
+        prompt: getTextFromMessage(userMessage as ChatMessage),
+      }).then(({ text }) =>
+        text
+          .replace(/^[#*"\s]+/, '')
+          .replace(/["]+$/, '')
+          .trim(),
+      );
+    }
+  }
+
+  if (userMessage && userMessage.role === 'user') {
+    await saveMessages({
+      messages: [
+        {
+          id: userMessage.id,
+          chatId: id,
+          role: 'user',
+          parts: userMessage.parts,
+          createdAt: new Date(),
+        },
+      ],
+    });
+  }
+
+  const uiMessages: ChatMessage[] = userMessage
+    ? [...convertToUIMessages(messagesFromDb), userMessage as ChatMessage]
+    : convertToUIMessages(messagesFromDb);
+
+  return { titlePromise, uiMessages };
+}
+
+// biome-ignore lint/style/useNamingConvention: Next.js HTTP method export
+export async function POST(request: Request) {
+  let requestBody: PostRequestBody;
+
+  try {
+    const json = await request.json();
+    requestBody = postRequestBodySchema.parse(json);
+  } catch {
+    return new ChatbotError('bad_request:api').toResponse();
+  }
+
+  try {
+    const { id, message, messages, model, selectedChatModel, provider, apiKey } = requestBody;
+
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return new ChatbotError('unauthorized:chat').toResponse();
+    }
+
+    const modelId = model ?? selectedChatModel;
+    const userMessage =
+      message ?? (messages && messages.length > 0 ? messages[messages.length - 1] : undefined);
+
+    const { titlePromise, uiMessages } = await prepareChatState({
+      id,
+      userId: user.id,
+      userMessage,
+      provider,
+      apiKey,
+    });
+
+    const modelMessages = await convertToModelMessages(uiMessages);
+
+    const stream = createUIMessageStream({
+      execute: async ({ writer: dataStream }) => {
+        const languageModel = getLanguageModel({ provider, modelId, apiKey });
+
+        const result = streamText({
+          model: languageModel,
+          instructions: systemPrompt,
+          messages: modelMessages,
+        });
+
+        dataStream.merge(
+          toUIMessageStream({
+            stream: result.stream,
+          }),
+        );
+
+        if (titlePromise) {
+          try {
+            const title = await titlePromise;
+            dataStream.write({ data: title, type: 'data-chat-title' });
+            await updateChatTitleById({ chatId: id, title });
+          } catch {
+            /* non-fatal title generation error */
+          }
+        }
+      },
+      onEnd: async ({ messages: finishedMessages }) => {
+        if (finishedMessages.length > 0) {
+          await saveMessages({
+            messages: finishedMessages.map((msg) => ({
+              id: msg.id,
+              chatId: id,
+              role: msg.role as 'user' | 'assistant' | 'system',
+              parts: msg.parts,
+              createdAt: new Date(),
+            })),
+          });
+        }
+      },
+    });
+
+    return createUIMessageStreamResponse({ stream });
+  } catch (error) {
+    if (error instanceof ChatbotError) {
+      return error.toResponse();
+    }
+    console.error('Unhandled error in POST /api/chat:', error);
+    return new ChatbotError('offline:chat').toResponse();
+  }
+}
+
+// biome-ignore lint/style/useNamingConvention: Next.js HTTP method export
+export async function DELETE(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const id = searchParams.get('id');
+
+    if (!id) {
+      return new ChatbotError('bad_request:api').toResponse();
+    }
+
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return new ChatbotError('unauthorized:chat').toResponse();
+    }
+
+    const chat = await getChatById({ id, userId: user.id });
+
+    if (!chat || chat.userId !== user.id) {
+      return new ChatbotError('forbidden:chat').toResponse();
+    }
+
+    const deletedChat = await deleteChatById({ id, userId: user.id });
+
+    return Response.json(deletedChat, { status: 200 });
+  } catch (error) {
+    if (error instanceof ChatbotError) {
+      return error.toResponse();
+    }
+    return new ChatbotError('offline:chat').toResponse();
+  }
+}

--- a/app/api/chat/schema.ts
+++ b/app/api/chat/schema.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+export const postRequestBodySchema = z.object({
+  id: z.string().uuid(),
+  message: z
+    .object({
+      id: z.string(),
+      role: z.enum(['user', 'assistant', 'system']),
+      parts: z.array(z.record(z.string(), z.unknown())),
+    })
+    .optional(),
+  messages: z
+    .array(
+      z.object({
+        id: z.string(),
+        role: z.enum(['user', 'assistant', 'system']),
+        parts: z.array(z.record(z.string(), z.unknown())),
+      }),
+    )
+    .optional(),
+  model: z.string().optional(),
+  selectedChatModel: z.string().optional(),
+  provider: z.enum(['google', 'openai', 'openrouter']).optional(),
+  apiKey: z.string().optional(),
+});
+
+export type PostRequestBody = z.infer<typeof postRequestBodySchema>;

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -1,0 +1,15 @@
+export const regularPrompt = `You are a helpful learning assistant for AI Learning Support. Keep responses concise, direct, and focused on active learning, clear explanations, and helping the user master complex concepts step-by-step.`;
+
+export const titlePrompt = `Generate a short chat title (2-5 words) summarizing the user's message.
+
+Output ONLY the title text. No prefixes, no formatting, no hashtags, no quotes.
+
+Examples:
+- "what's the weather in nyc" -> Weather in NYC
+- "help me write an essay about space" -> Space Essay Help
+- "hi" -> New Conversation
+- "explain fsrs spaced repetition" -> FSRS Spaced Repetition
+
+Never output hashtags, prefixes like "Title:", or quotes.`;
+
+export const systemPrompt = regularPrompt;

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -1,0 +1,53 @@
+import { createGoogle, google } from '@ai-sdk/google';
+import { createOpenAI, openai } from '@ai-sdk/openai';
+import type { LanguageModel } from 'ai';
+
+export type ProviderName = 'google' | 'openai' | 'openrouter';
+
+export type GetLanguageModelOptions = {
+  provider?: ProviderName;
+  modelId?: string;
+  apiKey?: string;
+};
+
+export const DEFAULT_PROVIDER: ProviderName = 'google';
+export const DEFAULT_MODEL_ID = 'gemini-2.5-flash';
+
+export function getLanguageModel({
+  provider = DEFAULT_PROVIDER,
+  modelId = DEFAULT_MODEL_ID,
+  apiKey,
+}: GetLanguageModelOptions = {}): LanguageModel {
+  switch (provider) {
+    case 'google': {
+      if (apiKey) {
+        return createGoogle({ apiKey })(modelId);
+      }
+      return google(modelId);
+    }
+    case 'openai': {
+      if (apiKey) {
+        return createOpenAI({ apiKey })(modelId);
+      }
+      return openai(modelId);
+    }
+    case 'openrouter': {
+      const key = apiKey || process.env.OPENROUTER_API_KEY;
+      return createOpenAI({
+        baseURL: 'https://openrouter.ai/api/v1',
+        apiKey: key,
+      })(modelId);
+    }
+    default: {
+      throw new Error(`Unsupported AI provider: ${provider}`);
+    }
+  }
+}
+
+export function getTitleModel(options: GetLanguageModelOptions = {}): LanguageModel {
+  return getLanguageModel({
+    provider: options.provider ?? DEFAULT_PROVIDER,
+    modelId: options.modelId ?? DEFAULT_MODEL_ID,
+    apiKey: options.apiKey,
+  });
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,11 @@
+import type { UIMessage } from 'ai';
+
+export type MessageMetadata = {
+  createdAt?: string;
+};
+
+export type CustomUIDataTypes = {
+  'chat-title': string;
+};
+
+export type ChatMessage = UIMessage;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,33 @@
+import type { UIMessage } from 'ai';
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import type { DBMessage } from '@/lib/db/schema';
+import type { ChatMessage } from '@/lib/types';
 
 export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));
+}
+
+export function generateUUID(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+export function convertToUIMessages(messages: DBMessage[]): ChatMessage[] {
+  return messages.map((message) => ({
+    id: message.id,
+    role: message.role as 'user' | 'assistant' | 'system',
+    parts: message.parts as UIMessage['parts'],
+  }));
+}
+
+export function getTextFromMessage(message: ChatMessage | UIMessage): string {
+  if (!message.parts) return '';
+  return message.parts
+    .filter((part) => part.type === 'text')
+    .map((part) => (part as { type: 'text'; text: string }).text)
+    .join('');
 }

--- a/specs/plan-index.md
+++ b/specs/plan-index.md
@@ -19,7 +19,7 @@ This directory contains technical implementation plans for feature development, 
   - Status: In Progress
   - Provider: Vercel AI SDK v7 (`streamText`), Drizzle ORM, Supabase Auth
   - **[Plan 006: Chat Database Schema & Query Encapsulation](plans/006-chat-database-schema-queries.md)** — Completed ([PR #51](https://github.com/69420pm/ai-learning-support-test/pull/51))
-  - **[Plan 007: Multi-LLM Provider & Streaming API Controller](plans/007-chat-ai-providers-streaming-api.md)** — Ready for Implementation
+  - **[Plan 007: Multi-LLM Provider & Streaming API Controller](plans/007-chat-ai-providers-streaming-api.md)** — Completed ([PR #52](https://github.com/69420pm/ai-learning-support-test/pull/52))
   - **[Plan 008: Interactive Chat UI & Code Syntax Highlighting](plans/008-chat-ui-components.md)** — Ready for Implementation
   - **[Plan 009: Page Routing, App Proxy Guard & Sidebar Thread History](plans/009-chat-routing-proxy-sidebar.md)** — Ready for Implementation
 


### PR DESCRIPTION
## Summary

Implements plan: `specs/plans/007-chat-ai-providers-streaming-api.md`

Established multi-LLM provider configuration in `lib/ai/providers.ts` (supporting Google Gemini, OpenAI, OpenRouter, and BYOK user keys) and a thin HTTP SSE streaming controller in `app/api/chat/route.ts` backed by AI SDK v7 `createUIMessageStream` + `createUIMessageStreamResponse` pipeline and Supabase Auth session guards.

## Changes

- Created `lib/ai/providers.ts` with `getLanguageModel` and `getTitleModel` supporting Google, OpenAI, OpenRouter, and custom API keys.
- Created `lib/ai/prompts.ts` with system prompts and title generation prompts.
- Created `app/api/chat/schema.ts` with Zod input validation schemas.
- Implemented `POST` and `DELETE` route handlers in `app/api/chat/route.ts` with Supabase Auth validation, PostgreSQL chat/message persistence via Drizzle ORM, real-time SSE streaming, and async title generation.
- Created domain types in `lib/types.ts` and message conversion utilities in `lib/utils.ts`.
- Implemented Vitest integration test suite in `app/api/chat/route.test.ts` verifying 401 unauthenticated guards, 400 validation errors, 403 forbidden access, 200 SSE streaming, and DB writes.

## Definition of Done

- [x] Provider Resolution: `lib/ai/providers.ts` exports `getLanguageModel({ provider, modelId, apiKey? })` supporting `'google'`, `'openai'`, and `'openrouter'`.
- [x] API Guard & Validation: `app/api/chat/route.ts` parses request body using Zod and rejects unauthenticated requests with HTTP 401.
- [x] Streaming & DB Persistence: Authenticated requests save user message to DB, stream response via AI SDK v7 pipeline, and persist assistant message on completion.
- [x] Title Generation: Newly created chats trigger non-blocking title generation and emit `chat-title` data stream event while updating DB.
- [x] API Integration Test: Vitest integration test in `app/api/chat/route.test.ts` verifies route handlers and DB writes.
- [x] Type Safety & Code Quality: Running `pnpm check` passes with zero errors.

## Verification

- [x] `pnpm check` passes (lint + typecheck + test)
- [x] Integration tests written and passing (`app/api/chat/route.test.ts`)
