### PR TITLE
feat(ai): model selection component & provider configuration

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -3,7 +3,15 @@
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "files": {
     "ignoreUnknown": true,
-    "includes": ["**", "!**/.next", "!**/node_modules", "!**/dist", "!**/.turbo", "!**/.agents"]
+    "includes": [
+      "**",
+      "!**/.next",
+      "!**/node_modules",
+      "!**/dist",
+      "!**/.turbo",
+      "!**/.agents",
+      "!**/next-env.d.ts"
+    ]
   },
   "formatter": {
     "enabled": true,

--- a/components/chat/chat-header.tsx
+++ b/components/chat/chat-header.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { PlusIcon, Sparkles } from 'lucide-react';
+import { PlusIcon } from 'lucide-react';
 import Link from 'next/link';
+import { ModelSelector } from '@/components/chat/model-selector';
 import { Button } from '@/components/ui/button';
+import { DEFAULT_MODEL_ID } from '@/lib/ai/providers';
 import { cn } from '@/lib/utils';
 
 export type ChatHeaderProps = {
@@ -15,8 +17,8 @@ export type ChatHeaderProps = {
 
 export function ChatHeader({
   title = 'New Chat',
-  selectedModelId = 'gemini-2.5-flash',
-  onModelChange: _onModelChange,
+  selectedModelId = DEFAULT_MODEL_ID,
+  onModelChange,
   onNewChat,
   className,
 }: ChatHeaderProps) {
@@ -32,10 +34,10 @@ export function ChatHeader({
           <h1 className="truncate font-semibold text-foreground text-sm sm:text-base">{title}</h1>
         </div>
 
-        <div className="hidden sm:flex items-center gap-1.5 rounded-full border border-border/60 bg-muted/50 px-2.5 py-1 text-xs text-muted-foreground">
-          <Sparkles className="size-3.5 text-primary" />
-          <span className="font-medium text-foreground">{selectedModelId}</span>
-        </div>
+        <ModelSelector
+          selectedModelId={selectedModelId}
+          onModelChange={onModelChange ?? (() => {})}
+        />
       </div>
 
       <div className="flex items-center gap-2">
@@ -61,3 +63,4 @@ export function ChatHeader({
     </header>
   );
 }
+

--- a/components/chat/chat-header.tsx
+++ b/components/chat/chat-header.tsx
@@ -63,4 +63,3 @@ export function ChatHeader({
     </header>
   );
 }
-

--- a/components/chat/chat.tsx
+++ b/components/chat/chat.tsx
@@ -9,6 +9,7 @@ import { ChatHeader } from '@/components/chat/chat-header';
 import { ChatInput } from '@/components/chat/chat-input';
 import { ChatMessages } from '@/components/chat/chat-messages';
 import { type CustomStreamPart, DataStreamHandler } from '@/components/chat/data-stream-handler';
+import { DEFAULT_MODEL_ID } from '@/lib/ai/providers';
 import type { ChatMessage } from '@/lib/types';
 import { cn, generateUUID } from '@/lib/utils';
 
@@ -25,16 +26,22 @@ export function Chat({
   id: initialId,
   initialMessages = [],
   initialTitle = 'New Chat',
-  selectedModelId = 'gemini-2.5-flash',
+  selectedModelId: initialSelectedModelId = DEFAULT_MODEL_ID,
   onModelChange,
   className,
 }: ChatProps) {
   const [chatId] = useState(() => initialId || generateUUID());
+  const [selectedModelId, setSelectedModelId] = useState(initialSelectedModelId);
   const [input, setInput] = useState('');
   const [title, setTitle] = useState(initialTitle);
   const [hasNavigated, setHasNavigated] = useState(Boolean(initialId));
   const [dataStreamParts, setDataStreamParts] = useState<CustomStreamPart[]>([]);
   const { mutate } = useSWRConfig();
+
+  const handleModelChange = (newModelId: string) => {
+    setSelectedModelId(newModelId);
+    onModelChange?.(newModelId);
+  };
 
   const transport = useMemo(
     () =>
@@ -86,7 +93,11 @@ export function Chat({
 
   return (
     <div className={cn('flex h-full w-full flex-col overflow-hidden bg-background', className)}>
-      <ChatHeader title={title} selectedModelId={selectedModelId} onModelChange={onModelChange} />
+      <ChatHeader
+        title={title}
+        selectedModelId={selectedModelId}
+        onModelChange={handleModelChange}
+      />
       <ChatMessages
         messages={messages}
         isLoading={status === 'streaming' || status === 'submitted'}

--- a/components/chat/model-selector.tsx
+++ b/components/chat/model-selector.tsx
@@ -12,11 +12,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import {
-  DEFAULT_MODEL_ID,
-  type ModelOption,
-  SUPPORTED_MODELS,
-} from '@/lib/ai/providers';
+import { DEFAULT_MODEL_ID, type ModelOption, SUPPORTED_MODELS } from '@/lib/ai/providers';
 import { cn } from '@/lib/utils';
 
 export type ModelSelectorProps = {
@@ -36,11 +32,7 @@ function getProviderIcon(provider: 'google' | 'openai') {
   }
 }
 
-export function ModelSelector({
-  selectedModelId,
-  onModelChange,
-  className,
-}: ModelSelectorProps) {
+export function ModelSelector({ selectedModelId, onModelChange, className }: ModelSelectorProps) {
   const [open, setOpen] = useState(false);
 
   const activeModel = useMemo(() => {
@@ -51,15 +43,9 @@ export function ModelSelector({
     );
   }, [selectedModelId]);
 
-  const googleModels = useMemo(
-    () => SUPPORTED_MODELS.filter((m) => m.provider === 'google'),
-    [],
-  );
+  const googleModels = useMemo(() => SUPPORTED_MODELS.filter((m) => m.provider === 'google'), []);
 
-  const openaiModels = useMemo(
-    () => SUPPORTED_MODELS.filter((m) => m.provider === 'openai'),
-    [],
-  );
+  const openaiModels = useMemo(() => SUPPORTED_MODELS.filter((m) => m.provider === 'openai'), []);
 
   const renderModelItem = (model: ModelOption) => {
     const isSelected = selectedModelId === model.id;
@@ -92,9 +78,7 @@ export function ModelSelector({
           </span>
         </div>
 
-        {isSelected && (
-          <Check className="size-4 shrink-0 text-primary self-center" />
-        )}
+        {isSelected && <Check className="size-4 shrink-0 text-primary self-center" />}
       </DropdownMenuItem>
     );
   };

--- a/components/chat/model-selector.tsx
+++ b/components/chat/model-selector.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { Bot, Check, ChevronDown, Cpu, Sparkles } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  DEFAULT_MODEL_ID,
+  type ModelOption,
+  SUPPORTED_MODELS,
+} from '@/lib/ai/providers';
+import { cn } from '@/lib/utils';
+
+export type ModelSelectorProps = {
+  selectedModelId: string;
+  onModelChange: (modelId: string) => void;
+  className?: string;
+};
+
+function getProviderIcon(provider: 'google' | 'openai') {
+  switch (provider) {
+    case 'google':
+      return <Sparkles className="size-3.5 text-amber-500 dark:text-amber-400" />;
+    case 'openai':
+      return <Cpu className="size-3.5 text-emerald-500 dark:text-emerald-400" />;
+    default:
+      return <Bot className="size-3.5 text-primary" />;
+  }
+}
+
+export function ModelSelector({
+  selectedModelId,
+  onModelChange,
+  className,
+}: ModelSelectorProps) {
+  const [open, setOpen] = useState(false);
+
+  const activeModel = useMemo(() => {
+    return (
+      SUPPORTED_MODELS.find((m) => m.id === selectedModelId) ??
+      SUPPORTED_MODELS.find((m) => m.id === DEFAULT_MODEL_ID) ??
+      SUPPORTED_MODELS[0]
+    );
+  }, [selectedModelId]);
+
+  const googleModels = useMemo(
+    () => SUPPORTED_MODELS.filter((m) => m.provider === 'google'),
+    [],
+  );
+
+  const openaiModels = useMemo(
+    () => SUPPORTED_MODELS.filter((m) => m.provider === 'openai'),
+    [],
+  );
+
+  const renderModelItem = (model: ModelOption) => {
+    const isSelected = selectedModelId === model.id;
+
+    return (
+      <DropdownMenuItem
+        key={model.id}
+        onSelect={() => {
+          onModelChange(model.id);
+          setOpen(false);
+        }}
+        className="flex cursor-pointer items-start justify-between gap-3 p-2.5 rounded-md focus:bg-accent focus:text-accent-foreground"
+        data-testid={`model-selector-item-${model.id}`}
+      >
+        <div className="flex flex-col gap-1 min-w-0">
+          <div className="flex items-center gap-1.5">
+            {getProviderIcon(model.provider)}
+            <span className="font-medium text-xs text-foreground">{model.name}</span>
+            {model.badge && (
+              <Badge
+                variant="secondary"
+                className="h-4 px-1.5 text-[10px] font-normal leading-none"
+              >
+                {model.badge}
+              </Badge>
+            )}
+          </div>
+          <span className="text-[11px] text-muted-foreground leading-normal">
+            {model.description}
+          </span>
+        </div>
+
+        {isSelected && (
+          <Check className="size-4 shrink-0 text-primary self-center" />
+        )}
+      </DropdownMenuItem>
+    );
+  };
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className={cn(
+            'h-8 gap-1.5 rounded-lg border-border/60 bg-muted/40 px-2.5 font-normal text-foreground text-xs shadow-none hover:bg-accent hover:text-accent-foreground focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:bg-accent',
+            className,
+          )}
+          data-testid="model-selector-trigger"
+        >
+          {getProviderIcon(activeModel.provider)}
+          <span className="font-medium">{activeModel.name}</span>
+          <ChevronDown className="size-3.5 text-muted-foreground transition-transform duration-200 data-[state=open]:rotate-180" />
+        </Button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align="start" className="w-[300px] p-1.5">
+        <DropdownMenuLabel className="px-2.5 py-1 font-semibold text-[10px] text-muted-foreground tracking-wider uppercase">
+          Google Gemini
+        </DropdownMenuLabel>
+        {googleModels.map(renderModelItem)}
+
+        <DropdownMenuSeparator className="my-1" />
+
+        <DropdownMenuLabel className="px-2.5 py-1 font-semibold text-[10px] text-muted-foreground tracking-wider uppercase">
+          OpenAI
+        </DropdownMenuLabel>
+        {openaiModels.map(renderModelItem)}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/lib/ai/providers.test.ts
+++ b/lib/ai/providers.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_MODEL_ID,
+  DEFAULT_PROVIDER,
+  getLanguageModel,
+  getTitleModel,
+  SUPPORTED_MODELS,
+} from './providers';
+
+describe('AI Providers Registry', () => {
+  it('exports DEFAULT_MODEL_ID as gemini-2.5-flash', () => {
+    expect(DEFAULT_MODEL_ID).toBe('gemini-2.5-flash');
+    expect(DEFAULT_PROVIDER).toBe('google');
+  });
+
+  it('exports SUPPORTED_MODELS list with Google and OpenAI models', () => {
+    expect(SUPPORTED_MODELS).toBeDefined();
+    expect(Array.isArray(SUPPORTED_MODELS)).toBe(true);
+    expect(SUPPORTED_MODELS.length).toBe(4);
+
+    const modelIds = SUPPORTED_MODELS.map((m) => m.id);
+    expect(modelIds).toContain('gemini-2.5-flash');
+    expect(modelIds).toContain('gemini-1.5-pro');
+    expect(modelIds).toContain('gpt-4o-mini');
+    expect(modelIds).toContain('gpt-4o');
+  });
+
+  it('resolves OpenAI model gpt-4o-mini without throwing', () => {
+    const model = getLanguageModel({ modelId: 'gpt-4o-mini' });
+    expect(model).toBeDefined();
+  });
+
+  it('resolves Google model gemini-1.5-pro without throwing', () => {
+    const model = getLanguageModel({ modelId: 'gemini-1.5-pro' });
+    expect(model).toBeDefined();
+  });
+
+  it('falls back to DEFAULT_MODEL_ID and logs warning when given invalid modelId', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const model = getLanguageModel({ modelId: 'non-existent-model' });
+
+    expect(model).toBeDefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unrecognized modelId "non-existent-model"'),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('resolves title model using default configuration', () => {
+    const model = getTitleModel();
+    expect(model).toBeDefined();
+  });
+});

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -5,6 +5,14 @@ import { MockLanguageModelV4 } from 'ai/test';
 
 export type ProviderName = 'google' | 'openai' | 'openrouter';
 
+export type ModelOption = {
+  id: string;
+  name: string;
+  provider: 'google' | 'openai';
+  description: string;
+  badge?: string;
+};
+
 export type GetLanguageModelOptions = {
   provider?: ProviderName;
   modelId?: string;
@@ -14,12 +22,58 @@ export type GetLanguageModelOptions = {
 export const DEFAULT_PROVIDER: ProviderName = 'google';
 export const DEFAULT_MODEL_ID = 'gemini-2.5-flash';
 
+export const SUPPORTED_MODELS: ModelOption[] = [
+  {
+    id: 'gemini-2.5-flash',
+    name: 'Gemini 2.5 Flash',
+    provider: 'google',
+    description: 'Fast & versatile model for multimodal tasks',
+    badge: 'Default',
+  },
+  {
+    id: 'gemini-1.5-pro',
+    name: 'Gemini 1.5 Pro',
+    provider: 'google',
+    description: 'Complex reasoning with 2M token context',
+  },
+  {
+    id: 'gpt-4o-mini',
+    name: 'GPT-4o mini',
+    provider: 'openai',
+    description: 'Fast, lightweight model for high-speed tasks',
+  },
+  {
+    id: 'gpt-4o',
+    name: 'GPT-4o',
+    provider: 'openai',
+    description: 'High-intelligence flagship model',
+  },
+];
+
 export function getLanguageModel({
-  provider = DEFAULT_PROVIDER,
+  provider,
   modelId = DEFAULT_MODEL_ID,
   apiKey,
 }: GetLanguageModelOptions = {}): LanguageModel {
-  const hasKey = apiKey || process.env.GOOGLE_GENERATIVE_AI_API_KEY || process.env.OPENAI_API_KEY;
+  let targetModel = SUPPORTED_MODELS.find((m) => m.id === modelId);
+  let resolvedModelId = modelId;
+
+  if (!targetModel) {
+    console.warn(
+      `Unrecognized modelId "${modelId}". Falling back to default model: ${DEFAULT_MODEL_ID}`,
+    );
+    targetModel = SUPPORTED_MODELS.find((m) => m.id === DEFAULT_MODEL_ID);
+    resolvedModelId = DEFAULT_MODEL_ID;
+  }
+
+  const resolvedProvider: ProviderName =
+    provider ?? (targetModel ? targetModel.provider : DEFAULT_PROVIDER);
+
+  const hasKey =
+    apiKey ||
+    process.env.GOOGLE_GENERATIVE_AI_API_KEY ||
+    process.env.OPENAI_API_KEY ||
+    process.env.OPENROUTER_API_KEY;
 
   if (!hasKey || process.env.PLAYWRIGHT_TEST === 'true') {
     return new MockLanguageModelV4({
@@ -58,35 +112,35 @@ export function getLanguageModel({
     });
   }
 
-  switch (provider) {
+  switch (resolvedProvider) {
     case 'google': {
       if (apiKey) {
-        return createGoogle({ apiKey })(modelId);
+        return createGoogle({ apiKey })(resolvedModelId);
       }
-      return google(modelId);
+      return google(resolvedModelId);
     }
     case 'openai': {
       if (apiKey) {
-        return createOpenAI({ apiKey })(modelId);
+        return createOpenAI({ apiKey })(resolvedModelId);
       }
-      return openai(modelId);
+      return openai(resolvedModelId);
     }
     case 'openrouter': {
       const key = apiKey || process.env.OPENROUTER_API_KEY;
       return createOpenAI({
         baseURL: 'https://openrouter.ai/api/v1',
         apiKey: key,
-      })(modelId);
+      })(resolvedModelId);
     }
     default: {
-      throw new Error(`Unsupported AI provider: ${provider}`);
+      throw new Error(`Unsupported AI provider: ${resolvedProvider}`);
     }
   }
 }
 
 export function getTitleModel(options: GetLanguageModelOptions = {}): LanguageModel {
   return getLanguageModel({
-    provider: options.provider ?? DEFAULT_PROVIDER,
+    provider: options.provider,
     modelId: options.modelId ?? DEFAULT_MODEL_ID,
     apiKey: options.apiKey,
   });

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts';
-import './.next/dev/types/root-params.d.ts';
+import "./.next/dev/types/routes.d.ts";
+import "./.next/dev/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/specs/plan-index.md
+++ b/specs/plan-index.md
@@ -22,3 +22,4 @@ This directory contains technical implementation plans for feature development, 
   - **[Plan 007: Multi-LLM Provider & Streaming API Controller](plans/007-chat-ai-providers-streaming-api.md)** — Completed ([PR #52](https://github.com/69420pm/ai-learning-support-test/pull/52))
   - **[Plan 008: Interactive Chat UI & Code Syntax Highlighting](plans/008-chat-ui-components.md)** — Completed ([PR #53](https://github.com/69420pm/ai-learning-support-test/pull/53))
   - **[Plan 009: Page Routing, App Proxy Guard & Sidebar Thread History](plans/009-chat-routing-proxy-sidebar.md)** — Completed ([PR #54](https://github.com/69420pm/ai-learning-support-test/pull/54))
+  - **[Plan 010: Model Selection Component & Provider Configuration](plans/010-model-selection-provider-config.md)** — Completed ([PR #56](https://github.com/69420pm/ai-learning-support-test/pull/56))

--- a/tests/e2e/chat.spec.ts
+++ b/tests/e2e/chat.spec.ts
@@ -61,7 +61,7 @@ test.describe('Chat Routing, App Proxy Guard & Sidebar Thread History E2E', () =
       await expect(page).toHaveURL(/\/chat/);
 
       await expect(chatPage.getChatTitle()).toHaveText('New Chat');
-      await expect(page.getByText('gemini-2.5-flash')).toBeVisible();
+      await expect(page.getByText('Gemini 2.5 Flash')).toBeVisible();
 
       await chatPage.sendUserMessage('Write a Python quicksort function');
       await expect(page.getByText(/Here is a Python quicksort/i)).toBeVisible({ timeout: 10000 });

--- a/tests/e2e/chat.spec.ts
+++ b/tests/e2e/chat.spec.ts
@@ -166,5 +166,23 @@ test.describe('Chat Routing, App Proxy Guard & Sidebar Thread History E2E', () =
       await chatPage.deleteChat(seededChatId);
       await expect(page.getByTestId(`chat-history-item-${seededChatId}`)).not.toBeVisible();
     });
+
+    test('allows user to switch AI model using model selector dropdown', async ({ page }) => {
+      const chatPage = new ChatPage(page);
+      await chatPage.goto();
+      await expect(page).toHaveURL(/\/chat/);
+
+      const modelTrigger = page.getByTestId('model-selector-trigger');
+      await expect(modelTrigger).toBeVisible();
+      await expect(modelTrigger).toHaveText(/Gemini 2\.5 Flash/);
+
+      await modelTrigger.click();
+
+      const gpt4oOption = page.getByTestId('model-selector-item-gpt-4o');
+      await expect(gpt4oOption).toBeVisible();
+      await gpt4oOption.click();
+
+      await expect(modelTrigger).toHaveText(/GPT-4o/);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Implements plan: `specs/plans/010-model-selection-provider-config.md`

- Adds `SUPPORTED_MODELS` registry and fallback model resolver in `lib/ai/providers.ts`.
- Builds reusable `ModelSelector` dropdown popover component in `components/chat/model-selector.tsx`.
- Integrates `ModelSelector` with active model state handling into `ChatHeader` and `Chat` components.

## Changes

- Export `ModelOption`, `SUPPORTED_MODELS` (Google Gemini 2.5 Flash, 1.5 Pro, OpenAI GPT-4o mini, GPT-4o), `DEFAULT_MODEL_ID`, and fallback resolver `getLanguageModel` in `lib/ai/providers.ts`.
- Create unit tests in `lib/ai/providers.test.ts`.
- Create `ModelSelector` dropdown popover in `components/chat/model-selector.tsx`.
- Connect model selection state in `components/chat/chat.tsx` & `components/chat/chat-header.tsx`.
- Add E2E tests for interactive model selection in `tests/e2e/chat.spec.ts`.

## Definition of Done

- [x] `lib/ai/providers.ts` exports `SUPPORTED_MODELS` array with Google & OpenAI model definitions and robust `getLanguageModel` fallback resolver.
- [x] `components/chat/model-selector.tsx` renders Popover dropdown displaying active model and selection checkmarks.
- [x] `pnpm check && pnpm test lib/ai/providers.test.ts` passes 100% cleanly.

## Verification

- [x] `pnpm check` passes (lint + typecheck + test)
- [x] Runtime verified via next-dev-loop (0 compilation/runtime errors)
- [x] UI verified via verifier subagent
- [x] E2E tests written and passing
- [x] Unit tests written and passing