### PR TITLE
feat(materials): deepen material lifecycle, upload intake, and cascade deletion seam (#80)

### DIFF
--- a/app/api/projects/[id]/materials/[materialId]/route.test.ts
+++ b/app/api/projects/[id]/materials/[materialId]/route.test.ts
@@ -17,25 +17,10 @@ vi.mock('@/lib/db/queries/project', () => ({
 }));
 
 const mockInspectMaterialContent = vi.fn();
+const mockDeleteMaterial = vi.fn();
 vi.mock('@/lib/materials', () => ({
   inspectMaterialContent: (...args: unknown[]) => mockInspectMaterialContent(...args),
-}));
-
-const mockGetMaterialById = vi.fn();
-const mockDeleteMaterialById = vi.fn();
-const mockDeleteMaterialChunksByMaterialId = vi.fn();
-vi.mock('@/lib/db/queries/material', () => ({
-  getMaterialById: (...args: unknown[]) => mockGetMaterialById(...args),
-  deleteMaterialById: (...args: unknown[]) => mockDeleteMaterialById(...args),
-  deleteMaterialChunksByMaterialId: (...args: unknown[]) =>
-    mockDeleteMaterialChunksByMaterialId(...args),
-}));
-
-const mockDeleteStorage = vi.fn();
-vi.mock('@/lib/storage', () => ({
-  getStorageDriver: () => ({
-    delete: (...args: unknown[]) => mockDeleteStorage(...args),
-  }),
+  deleteMaterial: (...args: unknown[]) => mockDeleteMaterial(...args),
 }));
 
 describe('Project Single Material API Route (/api/projects/[id]/materials/[materialId])', () => {
@@ -218,9 +203,11 @@ describe('Project Single Material API Route (/api/projects/[id]/materials/[mater
       });
 
       expect(response.status).toBe(401);
+      const json = await response.json();
+      expect(json.code).toBe('unauthorized:chat');
     });
 
-    it('returns 404 when project does not exist', async () => {
+    it('returns 404 when project does not exist for user', async () => {
       mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
       mockGetProjectById.mockResolvedValueOnce(null);
 
@@ -232,38 +219,26 @@ describe('Project Single Material API Route (/api/projects/[id]/materials/[mater
       });
 
       expect(response.status).toBe(404);
+      const json = await response.json();
+      expect(json.code).toBe('not_found:chat');
+      expect(mockGetProjectById).toHaveBeenCalledWith({ id: 'proj-1', userId: 'user-1' });
     });
 
-    it('returns 404 when material does not exist', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
-      mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', userId: 'user-1' });
-      mockGetMaterialById.mockResolvedValueOnce(null);
-
-      const request = new Request('http://localhost:3000/api/projects/proj-1/materials/mat-1', {
-        method: 'DELETE',
-      });
-      const response = await DELETE(request, {
-        params: Promise.resolve({ id: 'proj-1', materialId: 'mat-1' }),
-      });
-
-      expect(response.status).toBe(404);
-    });
-
-    it('atomically cascades deletion across chunks, db record, and physical storage blob', async () => {
+    it('delegates to deleteMaterial domain function and returns 200 with success and materialId', async () => {
       mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
       mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', userId: 'user-1' });
 
-      const mockMaterial = {
-        id: 'mat-1',
-        projectId: 'proj-1',
-        userId: 'user-1',
-        title: 'Notes',
-        storagePath: 'proj-1/uuid-notes.pdf',
-      };
-      mockGetMaterialById.mockResolvedValueOnce(mockMaterial);
-      mockDeleteMaterialChunksByMaterialId.mockResolvedValueOnce(undefined);
-      mockDeleteMaterialById.mockResolvedValueOnce(mockMaterial);
-      mockDeleteStorage.mockResolvedValueOnce(undefined);
+      mockDeleteMaterial.mockResolvedValueOnce({
+        success: true,
+        materialId: 'mat-1',
+        material: {
+          id: 'mat-1',
+          projectId: 'proj-1',
+          userId: 'user-1',
+          title: 'Notes',
+          storagePath: 'proj-1/uuid-notes.pdf',
+        },
+      });
 
       const request = new Request('http://localhost:3000/api/projects/proj-1/materials/mat-1', {
         method: 'DELETE',
@@ -276,13 +251,88 @@ describe('Project Single Material API Route (/api/projects/[id]/materials/[mater
       const json = await response.json();
       expect(json).toEqual({ success: true, materialId: 'mat-1' });
 
-      expect(mockDeleteMaterialChunksByMaterialId).toHaveBeenCalledWith({ materialId: 'mat-1' });
-      expect(mockDeleteMaterialById).toHaveBeenCalledWith({
-        id: 'mat-1',
+      expect(mockDeleteMaterial).toHaveBeenCalledWith({
+        materialId: 'mat-1',
         projectId: 'proj-1',
         userId: 'user-1',
       });
-      expect(mockDeleteStorage).toHaveBeenCalledWith('proj-1/uuid-notes.pdf');
+    });
+
+    it('maps not_found domain ChatbotError from deleteMaterial to 404 response', async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', userId: 'user-1' });
+      mockDeleteMaterial.mockRejectedValueOnce(
+        new ChatbotError('not_found:document', 'Material not found.'),
+      );
+
+      const request = new Request('http://localhost:3000/api/projects/proj-1/materials/mat-1', {
+        method: 'DELETE',
+      });
+      const response = await DELETE(request, {
+        params: Promise.resolve({ id: 'proj-1', materialId: 'mat-1' }),
+      });
+
+      expect(response.status).toBe(404);
+      const json = await response.json();
+      expect(json.code).toBe('not_found:document');
+      expect(json.cause).toBe('Material not found.');
+    });
+
+    it('maps forbidden domain ChatbotError from deleteMaterial to 403 response', async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', userId: 'user-1' });
+      mockDeleteMaterial.mockRejectedValueOnce(
+        new ChatbotError('forbidden:document', 'This document belongs to another user.'),
+      );
+
+      const request = new Request('http://localhost:3000/api/projects/proj-1/materials/mat-1', {
+        method: 'DELETE',
+      });
+      const response = await DELETE(request, {
+        params: Promise.resolve({ id: 'proj-1', materialId: 'mat-1' }),
+      });
+
+      expect(response.status).toBe(403);
+      const json = await response.json();
+      expect(json.code).toBe('forbidden:document');
+      expect(json.cause).toBe('This document belongs to another user.');
+    });
+
+    it('maps bad_request domain ChatbotError from deleteMaterial to 400 response', async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', userId: 'user-1' });
+      mockDeleteMaterial.mockRejectedValueOnce(
+        new ChatbotError('bad_request:document', 'A valid material ID is required.'),
+      );
+
+      const request = new Request('http://localhost:3000/api/projects/proj-1/materials/mat-1', {
+        method: 'DELETE',
+      });
+      const response = await DELETE(request, {
+        params: Promise.resolve({ id: 'proj-1', materialId: 'mat-1' }),
+      });
+
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.code).toBe('bad_request:document');
+      expect(json.cause).toBe('A valid material ID is required.');
+    });
+
+    it('returns 400 bad_request:api when an unexpected error occurs during deletion', async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', userId: 'user-1' });
+      mockDeleteMaterial.mockRejectedValueOnce(new Error('Unexpected database failure'));
+
+      const request = new Request('http://localhost:3000/api/projects/proj-1/materials/mat-1', {
+        method: 'DELETE',
+      });
+      const response = await DELETE(request, {
+        params: Promise.resolve({ id: 'proj-1', materialId: 'mat-1' }),
+      });
+
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.code).toBe('bad_request:api');
     });
   });
 });

--- a/app/api/projects/[id]/materials/[materialId]/route.test.ts
+++ b/app/api/projects/[id]/materials/[materialId]/route.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatbotError } from '@/lib/errors';
 import { DELETE, GET } from './route';
 
 const mockGetUser = vi.fn();
@@ -15,14 +16,17 @@ vi.mock('@/lib/db/queries/project', () => ({
   getProjectById: (...args: unknown[]) => mockGetProjectById(...args),
 }));
 
+const mockInspectMaterialContent = vi.fn();
+vi.mock('@/lib/materials', () => ({
+  inspectMaterialContent: (...args: unknown[]) => mockInspectMaterialContent(...args),
+}));
+
 const mockGetMaterialById = vi.fn();
 const mockDeleteMaterialById = vi.fn();
-const mockGetMaterialChunksByMaterialId = vi.fn();
 const mockDeleteMaterialChunksByMaterialId = vi.fn();
 vi.mock('@/lib/db/queries/material', () => ({
   getMaterialById: (...args: unknown[]) => mockGetMaterialById(...args),
   deleteMaterialById: (...args: unknown[]) => mockDeleteMaterialById(...args),
-  getMaterialChunksByMaterialId: (...args: unknown[]) => mockGetMaterialChunksByMaterialId(...args),
   deleteMaterialChunksByMaterialId: (...args: unknown[]) =>
     mockDeleteMaterialChunksByMaterialId(...args),
 }));
@@ -49,6 +53,8 @@ describe('Project Single Material API Route (/api/projects/[id]/materials/[mater
       });
 
       expect(response.status).toBe(401);
+      const json = await response.json();
+      expect(json.code).toBe('unauthorized:chat');
     });
 
     it('returns 404 when project does not exist for user', async () => {
@@ -61,65 +67,55 @@ describe('Project Single Material API Route (/api/projects/[id]/materials/[mater
       });
 
       expect(response.status).toBe(404);
+      expect(mockGetProjectById).toHaveBeenCalledWith({ id: 'proj-1', userId: 'user-1' });
     });
 
-    it('returns 404 when material does not exist', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
-      mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', userId: 'user-1' });
-      mockGetMaterialById.mockResolvedValueOnce(null);
-
-      const request = new Request('http://localhost:3000/api/projects/proj-1/materials/mat-1');
-      const response = await GET(request, {
-        params: Promise.resolve({ id: 'proj-1', materialId: 'mat-1' }),
-      });
-
-      expect(response.status).toBe(404);
-    });
-
-    it('returns 200 with material metadata and chunk list', async () => {
+    it('delegates to inspectMaterialContent and returns 200 with material, chunks, and content', async () => {
       mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
       mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', userId: 'user-1' });
 
-      const mockMaterial = {
-        id: 'mat-1',
-        projectId: 'proj-1',
-        userId: 'user-1',
-        title: 'Quantum Computing Notes',
-        filename: 'quantum.pdf',
-        fileType: 'application/pdf',
-        fileSize: 2048,
-        storagePath: 'proj-1/quantum.pdf',
-        status: 'ready',
-        metadata: { pageCount: 2, chunkCount: 2, tokenCount: 250 },
-        createdAt: '2026-08-20T17:00:00.000Z',
+      const mockInspectionResult = {
+        material: {
+          id: 'mat-1',
+          projectId: 'proj-1',
+          userId: 'user-1',
+          title: 'Quantum Computing Notes',
+          filename: 'quantum.pdf',
+          fileType: 'application/pdf',
+          fileSize: 2048,
+          storagePath: 'proj-1/quantum.pdf',
+          status: 'ready' as const,
+          metadata: { pageCount: 2, chunkCount: 2, tokenCount: 250 },
+          createdAt: new Date('2026-08-20T17:00:00.000Z'),
+        },
+        chunks: [
+          {
+            id: 'chunk-1',
+            materialId: 'mat-1',
+            projectId: 'proj-1',
+            userId: 'user-1',
+            chunkIndex: 0,
+            content: '## Section 1: Qubits\nQubits can exist in superposition.',
+            tokenCount: 120,
+            metadata: { pageNumber: 1 },
+            createdAt: new Date('2026-08-20T17:01:00.000Z'),
+          },
+          {
+            id: 'chunk-2',
+            materialId: 'mat-1',
+            projectId: 'proj-1',
+            userId: 'user-1',
+            chunkIndex: 1,
+            content: '## Section 2: Entanglement\nQuantum entanglement connects particles.',
+            tokenCount: 130,
+            metadata: { pageNumber: 2 },
+            createdAt: new Date('2026-08-20T17:01:01.000Z'),
+          },
+        ],
+        content:
+          '## Section 1: Qubits\nQubits can exist in superposition.\n\n## Section 2: Entanglement\nQuantum entanglement connects particles.',
       };
-      mockGetMaterialById.mockResolvedValueOnce(mockMaterial);
-
-      const mockChunks = [
-        {
-          id: 'chunk-1',
-          materialId: 'mat-1',
-          projectId: 'proj-1',
-          userId: 'user-1',
-          chunkIndex: 0,
-          content: '## Section 1: Qubits\nQubits can exist in superposition.',
-          tokenCount: 120,
-          metadata: { pageNumber: 1 },
-          createdAt: '2026-08-20T17:01:00.000Z',
-        },
-        {
-          id: 'chunk-2',
-          materialId: 'mat-1',
-          projectId: 'proj-1',
-          userId: 'user-1',
-          chunkIndex: 1,
-          content: '## Section 2: Entanglement\nQuantum entanglement connects particles.',
-          tokenCount: 130,
-          metadata: { pageNumber: 2 },
-          createdAt: '2026-08-20T17:01:01.000Z',
-        },
-      ];
-      mockGetMaterialChunksByMaterialId.mockResolvedValueOnce(mockChunks);
+      mockInspectMaterialContent.mockResolvedValueOnce(mockInspectionResult);
 
       const request = new Request('http://localhost:3000/api/projects/proj-1/materials/mat-1');
       const response = await GET(request, {
@@ -128,10 +124,85 @@ describe('Project Single Material API Route (/api/projects/[id]/materials/[mater
 
       expect(response.status).toBe(200);
       const json = await response.json();
-      expect(json.material).toEqual(mockMaterial);
-      expect(json.chunks).toEqual(mockChunks);
+      expect(json.material.id).toBe('mat-1');
+      expect(json.chunks).toHaveLength(2);
       expect(json.content).toContain('## Section 1: Qubits');
       expect(json.content).toContain('## Section 2: Entanglement');
+
+      expect(mockInspectMaterialContent).toHaveBeenCalledWith({
+        materialId: 'mat-1',
+        projectId: 'proj-1',
+        userId: 'user-1',
+      });
+    });
+
+    it('maps not_found domain ChatbotError from inspectMaterialContent to 404 response', async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', userId: 'user-1' });
+      mockInspectMaterialContent.mockRejectedValueOnce(
+        new ChatbotError('not_found:document', 'Material not found.'),
+      );
+
+      const request = new Request('http://localhost:3000/api/projects/proj-1/materials/mat-1');
+      const response = await GET(request, {
+        params: Promise.resolve({ id: 'proj-1', materialId: 'mat-1' }),
+      });
+
+      expect(response.status).toBe(404);
+      const json = await response.json();
+      expect(json.code).toBe('not_found:document');
+      expect(json.cause).toBe('Material not found.');
+    });
+
+    it('maps forbidden domain ChatbotError from inspectMaterialContent to 403 response', async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', userId: 'user-1' });
+      mockInspectMaterialContent.mockRejectedValueOnce(
+        new ChatbotError('forbidden:document', 'This document belongs to another user.'),
+      );
+
+      const request = new Request('http://localhost:3000/api/projects/proj-1/materials/mat-1');
+      const response = await GET(request, {
+        params: Promise.resolve({ id: 'proj-1', materialId: 'mat-1' }),
+      });
+
+      expect(response.status).toBe(403);
+      const json = await response.json();
+      expect(json.code).toBe('forbidden:document');
+      expect(json.cause).toBe('This document belongs to another user.');
+    });
+
+    it('maps bad_request domain ChatbotError from inspectMaterialContent to 400 response', async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', userId: 'user-1' });
+      mockInspectMaterialContent.mockRejectedValueOnce(
+        new ChatbotError('bad_request:document', 'Invalid inspection request parameters.'),
+      );
+
+      const request = new Request('http://localhost:3000/api/projects/proj-1/materials/mat-1');
+      const response = await GET(request, {
+        params: Promise.resolve({ id: 'proj-1', materialId: 'mat-1' }),
+      });
+
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.code).toBe('bad_request:document');
+      expect(json.cause).toBe('Invalid inspection request parameters.');
+    });
+
+    it('returns 400 bad_request:api when an unexpected error occurs during inspection', async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', userId: 'user-1' });
+      mockInspectMaterialContent.mockRejectedValueOnce(new Error('Unexpected DB timeout'));
+
+      const request = new Request('http://localhost:3000/api/projects/proj-1/materials/mat-1');
+      const response = await GET(request, {
+        params: Promise.resolve({ id: 'proj-1', materialId: 'mat-1' }),
+      });
+
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.code).toBe('bad_request:api');
     });
   });
 

--- a/app/api/projects/[id]/materials/[materialId]/route.ts
+++ b/app/api/projects/[id]/materials/[materialId]/route.ts
@@ -2,10 +2,10 @@ import {
   deleteMaterialById,
   deleteMaterialChunksByMaterialId,
   getMaterialById,
-  getMaterialChunksByMaterialId,
 } from '@/lib/db/queries/material';
 import { getProjectById } from '@/lib/db/queries/project';
 import { ChatbotError } from '@/lib/errors';
+import { inspectMaterialContent } from '@/lib/materials';
 import { getStorageDriver } from '@/lib/storage';
 import { createClient } from '@/lib/supabase/server';
 
@@ -32,13 +32,11 @@ export async function GET(
       return new ChatbotError('not_found:chat', 'Project not found').toResponse();
     }
 
-    const material = await getMaterialById({ id: materialId, projectId, userId: user.id });
-    if (!material) {
-      return new ChatbotError('not_found:document', 'Material not found').toResponse();
-    }
-
-    const chunks = await getMaterialChunksByMaterialId({ materialId });
-    const content = chunks.map((chunk) => chunk.content).join('\n\n');
+    const { material, chunks, content } = await inspectMaterialContent({
+      materialId,
+      projectId,
+      userId: user.id,
+    });
 
     return Response.json({ material, chunks, content }, { status: 200 });
   } catch (error) {

--- a/app/api/projects/[id]/materials/[materialId]/route.ts
+++ b/app/api/projects/[id]/materials/[materialId]/route.ts
@@ -1,12 +1,6 @@
-import {
-  deleteMaterialById,
-  deleteMaterialChunksByMaterialId,
-  getMaterialById,
-} from '@/lib/db/queries/material';
 import { getProjectById } from '@/lib/db/queries/project';
 import { ChatbotError } from '@/lib/errors';
-import { inspectMaterialContent } from '@/lib/materials';
-import { getStorageDriver } from '@/lib/storage';
+import { deleteMaterial, inspectMaterialContent } from '@/lib/materials';
 import { createClient } from '@/lib/supabase/server';
 
 export const maxDuration = 60;
@@ -68,29 +62,16 @@ export async function DELETE(
       return new ChatbotError('not_found:chat', 'Project not found').toResponse();
     }
 
-    const material = await getMaterialById({ id: materialId, projectId, userId: user.id });
-    if (!material) {
-      return new ChatbotError('not_found:document', 'Material not found').toResponse();
-    }
+    const result = await deleteMaterial({
+      materialId,
+      projectId,
+      userId: user.id,
+    });
 
-    // 1. Delete associated chunks
-    await deleteMaterialChunksByMaterialId({ materialId });
-
-    // 2. Delete database record
-    await deleteMaterialById({ id: materialId, projectId, userId: user.id });
-
-    // 3. Delete physical storage blob
-    try {
-      const storageDriver = getStorageDriver();
-      await storageDriver.delete(material.storagePath);
-    } catch (storageError) {
-      console.error(
-        `Failed to delete physical storage blob at ${material.storagePath}:`,
-        storageError,
-      );
-    }
-
-    return Response.json({ success: true, materialId }, { status: 200 });
+    return Response.json(
+      { success: result.success, materialId: result.materialId },
+      { status: 200 },
+    );
   } catch (error) {
     if (error instanceof ChatbotError) {
       return error.toResponse();

--- a/app/api/projects/[id]/materials/route.test.ts
+++ b/app/api/projects/[id]/materials/route.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatbotError } from '@/lib/errors';
 import { GET, POST } from './route';
 
 const mockGetUser = vi.fn();
@@ -15,23 +16,14 @@ vi.mock('@/lib/db/queries/project', () => ({
   getProjectById: (...args: unknown[]) => mockGetProjectById(...args),
 }));
 
-const mockCreateMaterial = vi.fn();
 const mockGetMaterialsByProjectId = vi.fn();
 vi.mock('@/lib/db/queries/material', () => ({
-  createMaterial: (...args: unknown[]) => mockCreateMaterial(...args),
   getMaterialsByProjectId: (...args: unknown[]) => mockGetMaterialsByProjectId(...args),
 }));
 
-const mockUpload = vi.fn();
-vi.mock('@/lib/storage', () => ({
-  getStorageDriver: () => ({
-    upload: (...args: unknown[]) => mockUpload(...args),
-  }),
-}));
-
-const mockSendIngestJob = vi.fn();
-vi.mock('@/lib/queue', () => ({
-  sendIngestJob: (...args: unknown[]) => mockSendIngestJob(...args),
+const mockIntakeMaterial = vi.fn();
+vi.mock('@/lib/materials', () => ({
+  intakeMaterial: (...args: unknown[]) => mockIntakeMaterial(...args),
 }));
 
 describe('Project Materials API Route (/api/projects/[id]/materials)', () => {
@@ -47,6 +39,8 @@ describe('Project Materials API Route (/api/projects/[id]/materials)', () => {
       const response = await GET(request, { params: Promise.resolve({ id: 'proj-1' }) });
 
       expect(response.status).toBe(401);
+      const json = await response.json();
+      expect(json.code).toBe('unauthorized:chat');
     });
 
     it('returns 404 when project does not exist for user', async () => {
@@ -57,6 +51,7 @@ describe('Project Materials API Route (/api/projects/[id]/materials)', () => {
       const response = await GET(request, { params: Promise.resolve({ id: 'proj-1' }) });
 
       expect(response.status).toBe(404);
+      expect(mockGetProjectById).toHaveBeenCalledWith({ id: 'proj-1', userId: 'user-1' });
     });
 
     it('returns 200 with list of materials for project', async () => {
@@ -77,6 +72,27 @@ describe('Project Materials API Route (/api/projects/[id]/materials)', () => {
       expect(response.status).toBe(200);
       const json = await response.json();
       expect(json.materials).toEqual(mockMaterials);
+      expect(mockGetMaterialsByProjectId).toHaveBeenCalledWith({
+        projectId: 'proj-1',
+        userId: 'user-1',
+      });
+    });
+
+    it('returns 400 when an unexpected error occurs during material query', async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockGetProjectById.mockResolvedValueOnce({
+        id: 'proj-1',
+        name: 'Calculus',
+        userId: 'user-1',
+      });
+      mockGetMaterialsByProjectId.mockRejectedValueOnce(new Error('DB connection failure'));
+
+      const request = new Request('http://localhost:3000/api/projects/proj-1/materials');
+      const response = await GET(request, { params: Promise.resolve({ id: 'proj-1' }) });
+
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.code).toBe('bad_request:api');
     });
   });
 
@@ -94,9 +110,11 @@ describe('Project Materials API Route (/api/projects/[id]/materials)', () => {
       const response = await POST(request, { params: Promise.resolve({ id: 'proj-1' }) });
 
       expect(response.status).toBe(401);
+      const json = await response.json();
+      expect(json.code).toBe('unauthorized:chat');
     });
 
-    it('returns 404 when project does not exist', async () => {
+    it('returns 404 when project does not exist or user is not owner', async () => {
       mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
       mockGetProjectById.mockResolvedValueOnce(null);
 
@@ -110,6 +128,7 @@ describe('Project Materials API Route (/api/projects/[id]/materials)', () => {
       const response = await POST(request, { params: Promise.resolve({ id: 'proj-1' }) });
 
       expect(response.status).toBe(404);
+      expect(mockGetProjectById).toHaveBeenCalledWith({ id: 'proj-1', userId: 'user-1' });
     });
 
     it('returns 400 when no file is uploaded', async () => {
@@ -130,9 +149,11 @@ describe('Project Materials API Route (/api/projects/[id]/materials)', () => {
       const response = await POST(request, { params: Promise.resolve({ id: 'proj-1' }) });
 
       expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.cause).toBe('A valid file is required');
     });
 
-    it('returns 400 for unsupported file types', async () => {
+    it('returns 400 when file payload is a string instead of File', async () => {
       mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
       mockGetProjectById.mockResolvedValueOnce({
         id: 'proj-1',
@@ -141,10 +162,7 @@ describe('Project Materials API Route (/api/projects/[id]/materials)', () => {
       });
 
       const formData = new FormData();
-      formData.append(
-        'file',
-        new File(['exe binary'], 'virus.exe', { type: 'application/x-msdownload' }),
-      );
+      formData.append('file', 'just-plain-string');
 
       const request = new Request('http://localhost:3000/api/projects/proj-1/materials', {
         method: 'POST',
@@ -153,34 +171,35 @@ describe('Project Materials API Route (/api/projects/[id]/materials)', () => {
       const response = await POST(request, { params: Promise.resolve({ id: 'proj-1' }) });
 
       expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.cause).toBe('A valid file is required');
     });
 
-    it('uploads file, creates record and dispatches ingestion job returning 201', async () => {
+    it('delegates to intakeMaterial with custom title and returns 201 on success', async () => {
       mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
       mockGetProjectById.mockResolvedValueOnce({
         id: 'proj-1',
         name: 'Calculus',
         userId: 'user-1',
       });
-      mockUpload.mockResolvedValueOnce({ path: 'proj-1/uuid-notes.md', size: 1024 });
 
-      const createdMat = {
+      const file = new File(['hello world'], 'notes.md', { type: 'text/markdown' });
+      const createdMaterial = {
         id: 'mat-1',
         projectId: 'proj-1',
         userId: 'user-1',
-        title: 'My Notes',
+        title: 'Custom Title',
         filename: 'notes.md',
         fileType: 'text/markdown',
         fileSize: 11,
         storagePath: 'proj-1/uuid-notes.md',
         status: 'pending',
       };
-      mockCreateMaterial.mockResolvedValueOnce(createdMat);
-      mockSendIngestJob.mockResolvedValueOnce('job-123');
+      mockIntakeMaterial.mockResolvedValueOnce(createdMaterial);
 
       const formData = new FormData();
-      formData.append('file', new File(['hello world'], 'notes.md', { type: 'text/markdown' }));
-      formData.append('title', 'My Notes');
+      formData.append('file', file);
+      formData.append('title', 'Custom Title');
 
       const request = new Request('http://localhost:3000/api/projects/proj-1/materials', {
         method: 'POST',
@@ -190,28 +209,113 @@ describe('Project Materials API Route (/api/projects/[id]/materials)', () => {
 
       expect(response.status).toBe(201);
       const json = await response.json();
-      expect(json.material).toEqual(createdMat);
+      expect(json.material).toEqual(createdMaterial);
 
-      expect(mockUpload).toHaveBeenCalledWith(
-        expect.stringContaining('proj-1/'),
-        expect.any(File),
-        'text/markdown',
-      );
-      expect(mockCreateMaterial).toHaveBeenCalledWith(
-        expect.objectContaining({
-          projectId: 'proj-1',
-          userId: 'user-1',
-          title: 'My Notes',
-          filename: 'notes.md',
-        }),
-      );
-      expect(mockSendIngestJob).toHaveBeenCalledWith({
-        materialId: 'mat-1',
+      expect(mockIntakeMaterial).toHaveBeenCalledWith({
         projectId: 'proj-1',
         userId: 'user-1',
-        storagePath: expect.stringContaining('proj-1/'),
-        fileType: 'text/markdown',
+        file,
+        title: 'Custom Title',
       });
+    });
+
+    it('delegates to intakeMaterial without title (undefined) and returns 201 on success', async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockGetProjectById.mockResolvedValueOnce({
+        id: 'proj-1',
+        name: 'Calculus',
+        userId: 'user-1',
+      });
+
+      const file = new File(['%PDF-1.4 sample'], 'slides.pdf', { type: 'application/pdf' });
+      const createdMaterial = {
+        id: 'mat-2',
+        projectId: 'proj-1',
+        userId: 'user-1',
+        title: 'slides.pdf',
+        filename: 'slides.pdf',
+        fileType: 'application/pdf',
+        fileSize: 15,
+        storagePath: 'proj-1/uuid-slides.pdf',
+        status: 'pending',
+      };
+      mockIntakeMaterial.mockResolvedValueOnce(createdMaterial);
+
+      const formData = new FormData();
+      formData.append('file', file);
+
+      const request = new Request('http://localhost:3000/api/projects/proj-1/materials', {
+        method: 'POST',
+        body: formData,
+      });
+      const response = await POST(request, { params: Promise.resolve({ id: 'proj-1' }) });
+
+      expect(response.status).toBe(201);
+      const json = await response.json();
+      expect(json.material).toEqual(createdMaterial);
+
+      expect(mockIntakeMaterial).toHaveBeenCalledWith({
+        projectId: 'proj-1',
+        userId: 'user-1',
+        file,
+        title: undefined,
+      });
+    });
+
+    it('maps domain ChatbotError from intakeMaterial to standard HTTP response', async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockGetProjectById.mockResolvedValueOnce({
+        id: 'proj-1',
+        name: 'Calculus',
+        userId: 'user-1',
+      });
+
+      mockIntakeMaterial.mockRejectedValueOnce(
+        new ChatbotError(
+          'bad_request:document',
+          'Unsupported file format (.exe). Supported: PDF, Markdown, Text, Images.',
+        ),
+      );
+
+      const formData = new FormData();
+      formData.append(
+        'file',
+        new File(['binary'], 'virus.exe', { type: 'application/x-msdownload' }),
+      );
+
+      const request = new Request('http://localhost:3000/api/projects/proj-1/materials', {
+        method: 'POST',
+        body: formData,
+      });
+      const response = await POST(request, { params: Promise.resolve({ id: 'proj-1' }) });
+
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.code).toBe('bad_request:document');
+      expect(json.cause).toContain('Unsupported file format (.exe)');
+    });
+
+    it('returns 400 when an unexpected error occurs during upload intake', async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockGetProjectById.mockResolvedValueOnce({
+        id: 'proj-1',
+        name: 'Calculus',
+        userId: 'user-1',
+      });
+      mockIntakeMaterial.mockRejectedValueOnce(new Error('Unexpected worker error'));
+
+      const formData = new FormData();
+      formData.append('file', new File(['hello'], 'notes.md', { type: 'text/markdown' }));
+
+      const request = new Request('http://localhost:3000/api/projects/proj-1/materials', {
+        method: 'POST',
+        body: formData,
+      });
+      const response = await POST(request, { params: Promise.resolve({ id: 'proj-1' }) });
+
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.code).toBe('bad_request:api');
     });
   });
 });

--- a/app/api/projects/[id]/materials/route.ts
+++ b/app/api/projects/[id]/materials/route.ts
@@ -1,55 +1,10 @@
-import { createMaterial, getMaterialsByProjectId } from '@/lib/db/queries/material';
+import { getMaterialsByProjectId } from '@/lib/db/queries/material';
 import { getProjectById } from '@/lib/db/queries/project';
 import { ChatbotError } from '@/lib/errors';
-import { sendIngestJob } from '@/lib/queue';
-import { getStorageDriver } from '@/lib/storage';
+import { intakeMaterial } from '@/lib/materials';
 import { createClient } from '@/lib/supabase/server';
 
 export const maxDuration = 60;
-
-const ALLOWED_MIME_TYPES = new Set([
-  'text/plain',
-  'text/markdown',
-  'text/x-markdown',
-  'application/pdf',
-  'application/x-pdf',
-  'image/png',
-  'image/jpeg',
-  'image/webp',
-  'image/gif',
-  'image/bmp',
-  'image/tiff',
-  'image/avif',
-  'application/octet-stream',
-]);
-
-const ALLOWED_EXTENSIONS = new Set([
-  '.txt',
-  '.md',
-  '.markdown',
-  '.pdf',
-  '.png',
-  '.jpg',
-  '.jpeg',
-  '.webp',
-  '.gif',
-  '.bmp',
-  '.tiff',
-  '.tif',
-  '.avif',
-]);
-
-function isValidMaterialFile(file: File): boolean {
-  const lastDot = file.name.lastIndexOf('.');
-  const extension = lastDot >= 0 ? file.name.slice(lastDot).toLowerCase() : '';
-  if (extension && ALLOWED_EXTENSIONS.has(extension)) {
-    return true;
-  }
-  if (file.type && ALLOWED_MIME_TYPES.has(file.type)) {
-    return true;
-  }
-  return Boolean(file.type?.startsWith('image/'));
-}
 
 // biome-ignore lint/style/useNamingConvention: Next.js HTTP method export
 export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
@@ -104,48 +59,15 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
       return new ChatbotError('bad_request:api', 'A valid file is required').toResponse();
     }
 
-    if (!isValidMaterialFile(file)) {
-      return new ChatbotError(
-        'bad_request:api',
-        'Only documents (.pdf, .md, .txt) and images (.png, .jpg, .webp, etc.) are supported',
-      ).toResponse();
-    }
-
-    // 25MB max file size
-    if (file.size > 25 * 1024 * 1024) {
-      return new ChatbotError('bad_request:api', 'File size exceeds 25MB limit').toResponse();
-    }
-
     const titleParam = formData.get('title');
     const title =
-      typeof titleParam === 'string' && titleParam.trim() ? titleParam.trim() : file.name;
+      typeof titleParam === 'string' && titleParam.trim() ? titleParam.trim() : undefined;
 
-    const fileType = file.type || 'text/markdown';
-    const sanitizedFilename = file.name.replace(/[^a-zA-Z0-9._-]/g, '_');
-    const storagePath = `${projectId}/${crypto.randomUUID()}-${sanitizedFilename}`;
-
-    // Upload payload using storage driver
-    const storageDriver = getStorageDriver();
-    await storageDriver.upload(storagePath, file, fileType);
-
-    // Record material in DB
-    const material = await createMaterial({
+    const material = await intakeMaterial({
       projectId,
       userId: user.id,
+      file,
       title,
-      filename: file.name,
-      fileType,
-      fileSize: file.size,
-      storagePath,
-    });
-
-    // Dispatch background ingestion job
-    await sendIngestJob({
-      materialId: material.id,
-      projectId,
-      userId: user.id,
-      storagePath,
-      fileType,
     });
 
     return Response.json({ material }, { status: 201 });

--- a/app/api/projects/[id]/route.test.ts
+++ b/app/api/projects/[id]/route.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatbotError } from '@/lib/errors';
 import { DELETE, PATCH } from './route';
 
 const mockGetUser = vi.fn();
@@ -11,14 +12,24 @@ vi.mock('@/lib/supabase/server', () => ({
 }));
 
 const mockUpdateProjectName = vi.fn();
+const mockGetProjectById = vi.fn();
 const mockDeleteProjectById = vi.fn();
 
 vi.mock('@/lib/db/queries/project', () => ({
   updateProjectName: (...args: unknown[]) => mockUpdateProjectName(...args),
+  getProjectById: (...args: unknown[]) => mockGetProjectById(...args),
   deleteProjectById: (...args: unknown[]) => mockDeleteProjectById(...args),
 }));
 
+const mockPurgeProjectMaterialsStorage = vi.fn();
+vi.mock('@/lib/materials', () => ({
+  purgeProjectMaterialsStorage: (...args: unknown[]) => mockPurgeProjectMaterialsStorage(...args),
+}));
+
 describe('Project Item API Route (/api/projects/[id])', () => {
+  const defaultUser = { id: 'user-1' };
+  const defaultProject = { id: 'p1', userId: 'user-1', name: 'Math' };
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -38,8 +49,7 @@ describe('Project Item API Route (/api/projects/[id])', () => {
     });
 
     it('returns 400 when name is invalid', async () => {
-      const testUser = { id: 'user-1' };
-      mockGetUser.mockResolvedValueOnce({ data: { user: testUser }, error: null });
+      mockGetUser.mockResolvedValueOnce({ data: { user: defaultUser }, error: null });
 
       const request = new Request('http://localhost:3000/api/projects/p1', {
         method: 'PATCH',
@@ -52,9 +62,8 @@ describe('Project Item API Route (/api/projects/[id])', () => {
     });
 
     it('updates project and returns 200', async () => {
-      const testUser = { id: 'user-1' };
-      mockGetUser.mockResolvedValueOnce({ data: { user: testUser }, error: null });
-      const updated = { id: 'p1', name: 'Updated Name', userId: 'user-1' };
+      mockGetUser.mockResolvedValueOnce({ data: { user: defaultUser }, error: null });
+      const updated = { id: 'p1', name: 'Updated Name', userId: defaultUser.id };
       mockUpdateProjectName.mockResolvedValueOnce(updated);
 
       const request = new Request('http://localhost:3000/api/projects/p1', {
@@ -86,29 +95,88 @@ describe('Project Item API Route (/api/projects/[id])', () => {
     });
 
     it('returns 404 when project does not exist or does not belong to user', async () => {
-      const testUser = { id: 'user-1' };
-      mockGetUser.mockResolvedValueOnce({ data: { user: testUser }, error: null });
-      mockDeleteProjectById.mockResolvedValueOnce(null);
+      mockGetUser.mockResolvedValueOnce({ data: { user: defaultUser }, error: null });
+      mockGetProjectById.mockResolvedValueOnce(null);
 
       const request = new Request('http://localhost:3000/api/projects/p1', { method: 'DELETE' });
       const response = await DELETE(request, { params: Promise.resolve({ id: 'p1' }) });
 
       expect(response.status).toBe(404);
+      expect(mockGetProjectById).toHaveBeenCalledWith({
+        id: 'p1',
+        userId: 'user-1',
+      });
+      expect(mockPurgeProjectMaterialsStorage).not.toHaveBeenCalled();
+      expect(mockDeleteProjectById).not.toHaveBeenCalled();
     });
 
-    it('deletes project and returns 200', async () => {
-      const testUser = { id: 'user-1' };
-      mockGetUser.mockResolvedValueOnce({ data: { user: testUser }, error: null });
-      mockDeleteProjectById.mockResolvedValueOnce({ id: 'p1', userId: 'user-1', name: 'Math' });
+    it('purges storage blobs and deletes project database record in order, returning 200', async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: defaultUser }, error: null });
+      mockGetProjectById.mockResolvedValueOnce(defaultProject);
+
+      const callOrder: string[] = [];
+      mockPurgeProjectMaterialsStorage.mockImplementationOnce(() => {
+        callOrder.push('purgeStorage');
+        return Promise.resolve({ purgedCount: 2, totalMaterials: 2 });
+      });
+      mockDeleteProjectById.mockImplementationOnce(() => {
+        callOrder.push('deleteDb');
+        return Promise.resolve(defaultProject);
+      });
 
       const request = new Request('http://localhost:3000/api/projects/p1', { method: 'DELETE' });
       const response = await DELETE(request, { params: Promise.resolve({ id: 'p1' }) });
 
       expect(response.status).toBe(200);
+      const json = await response.json();
+      expect(json).toEqual({ success: true, message: 'Project deleted successfully' });
+
+      expect(mockGetProjectById).toHaveBeenCalledWith({
+        id: 'p1',
+        userId: 'user-1',
+      });
+      expect(mockPurgeProjectMaterialsStorage).toHaveBeenCalledWith({
+        projectId: 'p1',
+        userId: 'user-1',
+      });
       expect(mockDeleteProjectById).toHaveBeenCalledWith({
         id: 'p1',
         userId: 'user-1',
       });
+
+      // Storage purge must occur BEFORE project db deletion to preserve material references
+      expect(callOrder).toEqual(['purgeStorage', 'deleteDb']);
+    });
+
+    it('maps domain ChatbotError from storage purge to error response', async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: defaultUser }, error: null });
+      mockGetProjectById.mockResolvedValueOnce(defaultProject);
+      mockPurgeProjectMaterialsStorage.mockRejectedValueOnce(
+        new ChatbotError('bad_request:document', 'A valid project ID is required.'),
+      );
+
+      const request = new Request('http://localhost:3000/api/projects/p1', { method: 'DELETE' });
+      const response = await DELETE(request, { params: Promise.resolve({ id: 'p1' }) });
+
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.code).toBe('bad_request:document');
+      expect(json.cause).toBe('A valid project ID is required.');
+      expect(mockDeleteProjectById).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 bad_request:api when an unexpected error occurs during deletion', async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: defaultUser }, error: null });
+      mockGetProjectById.mockResolvedValueOnce(defaultProject);
+      mockPurgeProjectMaterialsStorage.mockRejectedValueOnce(new Error('Unexpected network crash'));
+
+      const request = new Request('http://localhost:3000/api/projects/p1', { method: 'DELETE' });
+      const response = await DELETE(request, { params: Promise.resolve({ id: 'p1' }) });
+
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.code).toBe('bad_request:api');
+      expect(mockDeleteProjectById).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/api/projects/[id]/route.ts
+++ b/app/api/projects/[id]/route.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
-import { deleteProjectById, updateProjectName } from '@/lib/db/queries/project';
+import { deleteProjectById, getProjectById, updateProjectName } from '@/lib/db/queries/project';
 import { ChatbotError } from '@/lib/errors';
+import { purgeProjectMaterialsStorage } from '@/lib/materials';
 import { createClient } from '@/lib/supabase/server';
 
 export const maxDuration = 60;
@@ -57,16 +58,29 @@ export async function DELETE(_request: Request, { params }: { params: Promise<{ 
       return new ChatbotError('unauthorized:chat').toResponse();
     }
 
-    const deleted = await deleteProjectById({
+    const project = await getProjectById({
       id,
       userId: user.id,
     });
 
-    if (!deleted) {
+    if (!project) {
       return new ChatbotError('not_found:chat', 'Project not found').toResponse();
     }
 
-    return new Response('Project deleted successfully', { status: 200 });
+    await purgeProjectMaterialsStorage({
+      projectId: id,
+      userId: user.id,
+    });
+
+    await deleteProjectById({
+      id,
+      userId: user.id,
+    });
+
+    return Response.json(
+      { success: true, message: 'Project deleted successfully' },
+      { status: 200 },
+    );
   } catch (error) {
     if (error instanceof ChatbotError) {
       return error.toResponse();

--- a/lib/db/queries/material.test.ts
+++ b/lib/db/queries/material.test.ts
@@ -113,6 +113,31 @@ describe('Material DB Queries', () => {
       });
       expect(result).toEqual(mockMaterials);
     });
+
+    it('returns materials when userId is omitted', async () => {
+      const mockMaterials = [
+        {
+          id: 'mat-1',
+          projectId: 'proj-1',
+          userId: 'user-1',
+          title: 'Notes',
+          createdAt: new Date(),
+        },
+      ];
+
+      mockSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValueOnce({
+          where: vi.fn().mockReturnValueOnce({
+            orderBy: vi.fn().mockResolvedValueOnce(mockMaterials),
+          }),
+        }),
+      });
+
+      const result = await getMaterialsByProjectId({
+        projectId: 'proj-1',
+      });
+      expect(result).toEqual(mockMaterials);
+    });
   });
 
   describe('getMaterialById', () => {

--- a/lib/db/queries/material.ts
+++ b/lib/db/queries/material.ts
@@ -62,13 +62,18 @@ export async function getMaterialsByProjectId({
   userId,
 }: {
   projectId: string;
-  userId: string;
+  userId?: string;
 }): Promise<Material[]> {
   try {
+    const conditions = [eq(materials.projectId, projectId)];
+    if (userId) {
+      conditions.push(eq(materials.userId, userId));
+    }
+
     return await db
       .select()
       .from(materials)
-      .where(and(eq(materials.projectId, projectId), eq(materials.userId, userId)))
+      .where(and(...conditions))
       .orderBy(desc(materials.createdAt));
   } catch (error) {
     throw new ChatbotError('bad_request:database', { cause: error });

--- a/lib/materials/deletion.test.ts
+++ b/lib/materials/deletion.test.ts
@@ -1,0 +1,357 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatbotError } from '@/lib/errors';
+import type { StorageDriver } from '@/lib/storage';
+import { LocalStorageDriver, resetStorageDriver } from '@/lib/storage';
+import { deleteMaterial } from './deletion';
+
+// Mock DB queries
+const mockGetMaterialById = vi.fn();
+const mockDeleteMaterialById = vi.fn();
+
+vi.mock('@/lib/db/queries/material', () => ({
+  getMaterialById: (...args: unknown[]) => mockGetMaterialById(...args),
+  deleteMaterialById: (...args: unknown[]) => mockDeleteMaterialById(...args),
+}));
+
+describe('Material Deletion Domain Logic', () => {
+  const defaultProjectId = '11111111-1111-1111-1111-111111111111';
+  const defaultUserId = '22222222-2222-2222-2222-222222222222';
+  const defaultMaterialId = '33333333-3333-3333-3333-333333333333';
+  const defaultStoragePath = `${defaultProjectId}/uuid-notes.pdf`;
+
+  const sampleMaterial = {
+    id: defaultMaterialId,
+    projectId: defaultProjectId,
+    userId: defaultUserId,
+    title: 'Lecture Notes',
+    filename: 'notes.pdf',
+    fileType: 'application/pdf',
+    fileSize: 1024,
+    storagePath: defaultStoragePath,
+    status: 'ready' as const,
+    errorMessage: null,
+    metadata: { pageCount: 5, chunkCount: 10 },
+    createdAt: new Date('2026-08-20T10:00:00.000Z'),
+    updatedAt: new Date('2026-08-20T10:05:00.000Z'),
+  };
+
+  let mockDeleteBlob: ReturnType<typeof vi.fn>;
+  let mockStorage: StorageDriver;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStorageDriver();
+
+    mockDeleteBlob = vi.fn().mockResolvedValue(undefined);
+    mockStorage = {
+      upload: vi.fn(),
+      download: vi.fn(),
+      delete: mockDeleteBlob,
+    } as unknown as StorageDriver;
+
+    mockGetMaterialById.mockResolvedValue({ ...sampleMaterial });
+    mockDeleteMaterialById.mockResolvedValue({ ...sampleMaterial });
+  });
+
+  describe('Successful Material Deletion Flow', () => {
+    it('verifies existence, deletes DB record, and purges physical storage blob', async () => {
+      const result = await deleteMaterial(
+        {
+          materialId: defaultMaterialId,
+          projectId: defaultProjectId,
+          userId: defaultUserId,
+        },
+        { storageDriver: mockStorage },
+      );
+
+      expect(result).toEqual({
+        success: true,
+        materialId: defaultMaterialId,
+        material: expect.objectContaining({
+          id: defaultMaterialId,
+          title: 'Lecture Notes',
+        }),
+      });
+
+      // 1. Verify existence check
+      expect(mockGetMaterialById).toHaveBeenCalledWith({ id: defaultMaterialId });
+
+      // 2. Verify database deletion
+      expect(mockDeleteMaterialById).toHaveBeenCalledWith({
+        id: defaultMaterialId,
+        projectId: defaultProjectId,
+        userId: defaultUserId,
+      });
+
+      // 3. Verify storage driver blob removal
+      expect(mockDeleteBlob).toHaveBeenCalledWith(defaultStoragePath);
+    });
+
+    it('allows deleting material without specifying optional projectId or userId', async () => {
+      const result = await deleteMaterial(
+        {
+          materialId: defaultMaterialId,
+        },
+        { storageDriver: mockStorage },
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockGetMaterialById).toHaveBeenCalledWith({ id: defaultMaterialId });
+      expect(mockDeleteMaterialById).toHaveBeenCalledWith({
+        id: defaultMaterialId,
+        projectId: defaultProjectId,
+        userId: defaultUserId,
+      });
+      expect(mockDeleteBlob).toHaveBeenCalledWith(defaultStoragePath);
+    });
+  });
+
+  describe('Non-Fatal Storage Error Handling', () => {
+    it('logs non-fatal error and completes cleanly when storage driver throws', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+        // Suppress error output in test
+      });
+      mockDeleteBlob.mockRejectedValueOnce(new Error('ENOENT: storage file missing on disk'));
+
+      const result = await deleteMaterial(
+        {
+          materialId: defaultMaterialId,
+          projectId: defaultProjectId,
+          userId: defaultUserId,
+        },
+        { storageDriver: mockStorage },
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.materialId).toBe(defaultMaterialId);
+      expect(mockDeleteMaterialById).toHaveBeenCalledTimes(1);
+      expect(mockDeleteBlob).toHaveBeenCalledWith(defaultStoragePath);
+
+      // Warning/error logged
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to delete physical storage blob'),
+        expect.any(Error),
+      );
+
+      errorSpy.mockRestore();
+    });
+
+    it('does not invoke storage driver if material has empty storagePath', async () => {
+      mockGetMaterialById.mockResolvedValueOnce({
+        ...sampleMaterial,
+        storagePath: '',
+      });
+      mockDeleteMaterialById.mockResolvedValueOnce({
+        ...sampleMaterial,
+        storagePath: '',
+      });
+
+      const result = await deleteMaterial(
+        {
+          materialId: defaultMaterialId,
+          projectId: defaultProjectId,
+          userId: defaultUserId,
+        },
+        { storageDriver: mockStorage },
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockDeleteBlob).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Not Found & Ownership Validation', () => {
+    it('throws not_found ChatbotError when material does not exist', async () => {
+      mockGetMaterialById.mockResolvedValue(null);
+
+      await expect(
+        deleteMaterial(
+          {
+            materialId: 'non-existent-id',
+            projectId: defaultProjectId,
+            userId: defaultUserId,
+          },
+          { storageDriver: mockStorage },
+        ),
+      ).rejects.toThrow(ChatbotError);
+
+      try {
+        await deleteMaterial(
+          {
+            materialId: 'non-existent-id',
+          },
+          { storageDriver: mockStorage },
+        );
+      } catch (err) {
+        expect(err).toBeInstanceOf(ChatbotError);
+        expect((err as ChatbotError).type).toBe('not_found');
+        expect((err as ChatbotError).surface).toBe('document');
+      }
+
+      expect(mockDeleteMaterialById).not.toHaveBeenCalled();
+      expect(mockDeleteBlob).not.toHaveBeenCalled();
+    });
+
+    it('throws forbidden ChatbotError when material belongs to another user', async () => {
+      mockGetMaterialById.mockResolvedValue({
+        ...sampleMaterial,
+        userId: 'other-user-uuid',
+      });
+
+      await expect(
+        deleteMaterial(
+          {
+            materialId: defaultMaterialId,
+            projectId: defaultProjectId,
+            userId: defaultUserId,
+          },
+          { storageDriver: mockStorage },
+        ),
+      ).rejects.toThrow(ChatbotError);
+
+      try {
+        await deleteMaterial(
+          {
+            materialId: defaultMaterialId,
+            projectId: defaultProjectId,
+            userId: defaultUserId,
+          },
+          { storageDriver: mockStorage },
+        );
+      } catch (err) {
+        expect(err).toBeInstanceOf(ChatbotError);
+        expect((err as ChatbotError).type).toBe('forbidden');
+        expect((err as ChatbotError).surface).toBe('document');
+      }
+
+      expect(mockDeleteMaterialById).not.toHaveBeenCalled();
+      expect(mockDeleteBlob).not.toHaveBeenCalled();
+    });
+
+    it('throws not_found ChatbotError when material belongs to another project', async () => {
+      mockGetMaterialById.mockResolvedValue({
+        ...sampleMaterial,
+        projectId: 'other-project-uuid',
+      });
+
+      await expect(
+        deleteMaterial(
+          {
+            materialId: defaultMaterialId,
+            projectId: defaultProjectId,
+            userId: defaultUserId,
+          },
+          { storageDriver: mockStorage },
+        ),
+      ).rejects.toThrow(ChatbotError);
+
+      try {
+        await deleteMaterial(
+          {
+            materialId: defaultMaterialId,
+            projectId: defaultProjectId,
+            userId: defaultUserId,
+          },
+          { storageDriver: mockStorage },
+        );
+      } catch (err) {
+        expect(err).toBeInstanceOf(ChatbotError);
+        expect((err as ChatbotError).type).toBe('not_found');
+        expect((err as ChatbotError).surface).toBe('document');
+      }
+
+      expect(mockDeleteMaterialById).not.toHaveBeenCalled();
+      expect(mockDeleteBlob).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Input Validation Constraints', () => {
+    it('throws bad_request ChatbotError when materialId is missing or empty', async () => {
+      await expect(
+        deleteMaterial(
+          {
+            materialId: '   ',
+          },
+          { storageDriver: mockStorage },
+        ),
+      ).rejects.toThrow(ChatbotError);
+
+      await expect(
+        deleteMaterial({} as unknown as { materialId: string }, { storageDriver: mockStorage }),
+      ).rejects.toThrow(ChatbotError);
+
+      expect(mockGetMaterialById).not.toHaveBeenCalled();
+      expect(mockDeleteMaterialById).not.toHaveBeenCalled();
+      expect(mockDeleteBlob).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('In-Process Integration with LocalStorageDriver', () => {
+    it('physically deletes file on disk and tolerates subsequent deletion gracefully', async () => {
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'test-storage-delete-'));
+      const localDriver = new LocalStorageDriver(tempDir);
+
+      try {
+        // Upload a real file
+        const uploadResult = await localDriver.upload(
+          'proj-1/real-file.txt',
+          'Hello real storage',
+          'text/plain',
+        );
+        const fullDiskPath = path.join(tempDir, 'proj-1', 'real-file.txt');
+        expect(await fs.stat(fullDiskPath)).toBeDefined();
+
+        mockGetMaterialById.mockResolvedValueOnce({
+          ...sampleMaterial,
+          storagePath: uploadResult.path,
+        });
+        mockDeleteMaterialById.mockResolvedValueOnce({
+          ...sampleMaterial,
+          storagePath: uploadResult.path,
+        });
+
+        // Delete using deleteMaterial
+        const result = await deleteMaterial(
+          {
+            materialId: defaultMaterialId,
+            projectId: defaultProjectId,
+            userId: defaultUserId,
+          },
+          { storageDriver: localDriver },
+        );
+
+        expect(result.success).toBe(true);
+        // Verify file is physically removed
+        await expect(fs.stat(fullDiskPath)).rejects.toThrow();
+
+        // Second deletion when file is already gone (tolerates ENOENT)
+        mockGetMaterialById.mockResolvedValueOnce({
+          ...sampleMaterial,
+          storagePath: uploadResult.path,
+        });
+        mockDeleteMaterialById.mockResolvedValueOnce({
+          ...sampleMaterial,
+          storagePath: uploadResult.path,
+        });
+
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+          // Suppress error output in test
+        });
+        const result2 = await deleteMaterial(
+          {
+            materialId: defaultMaterialId,
+          },
+          { storageDriver: localDriver },
+        );
+
+        expect(result2.success).toBe(true);
+        errorSpy.mockRestore();
+      } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/lib/materials/deletion.ts
+++ b/lib/materials/deletion.ts
@@ -1,0 +1,82 @@
+import { deleteMaterialById, getMaterialById } from '@/lib/db/queries/material';
+import type { Material } from '@/lib/db/schema';
+import { ChatbotError } from '@/lib/errors';
+import { getStorageDriver, type StorageDriver } from '@/lib/storage';
+
+export type DeleteMaterialInput = {
+  materialId: string;
+  projectId?: string;
+  userId?: string;
+};
+
+export type DeleteMaterialOptions = {
+  storageDriver?: StorageDriver;
+};
+
+export type DeleteMaterialResult = {
+  success: boolean;
+  materialId: string;
+  material: Material;
+};
+
+/**
+ * Core Material Deletion domain function.
+ * Verifies material existence and ownership scoping, deletes the database record
+ * (leveraging PostgreSQL foreign key cascade for chunk records), and purges the
+ * physical file from the storage driver. If storage deletion fails (e.g. file already
+ * deleted or missing), a non-fatal warning is logged to ensure database deletion completes cleanly.
+ */
+export async function deleteMaterial(
+  input: DeleteMaterialInput,
+  options?: DeleteMaterialOptions,
+): Promise<DeleteMaterialResult> {
+  const materialId = input?.materialId?.trim();
+
+  if (!materialId) {
+    throw new ChatbotError('bad_request:document', 'A valid material ID is required.');
+  }
+
+  // 1. Verify existence of material record
+  const material = await getMaterialById({ id: materialId });
+  if (!material) {
+    throw new ChatbotError('not_found:document', 'Material not found.');
+  }
+
+  // 2. Validate ownership scoping if userId or projectId are provided
+  if (input.userId && material.userId !== input.userId) {
+    throw new ChatbotError('forbidden:document', 'This document belongs to another user.');
+  }
+
+  if (input.projectId && material.projectId !== input.projectId) {
+    throw new ChatbotError(
+      'not_found:document',
+      'Material does not belong to the specified project.',
+    );
+  }
+
+  // 3. Delete database record (chunks cascade automatically via DB foreign key)
+  await deleteMaterialById({
+    id: materialId,
+    projectId: material.projectId,
+    userId: material.userId,
+  });
+
+  // 4. Purge physical storage blob via storage driver seam
+  if (material.storagePath && material.storagePath.trim().length > 0) {
+    const storageDriver = options?.storageDriver ?? getStorageDriver();
+    try {
+      await storageDriver.delete(material.storagePath);
+    } catch (storageError) {
+      console.error(
+        `Failed to delete physical storage blob at "${material.storagePath}" for material "${materialId}":`,
+        storageError,
+      );
+    }
+  }
+
+  return {
+    success: true,
+    materialId: material.id,
+    material,
+  };
+}

--- a/lib/materials/index.ts
+++ b/lib/materials/index.ts
@@ -1,5 +1,6 @@
 export * from './chunker';
 export * from './ingestion';
+export * from './intake';
 export * from './rasterizer';
 export * from './validation';
 export * from './vision';

--- a/lib/materials/index.ts
+++ b/lib/materials/index.ts
@@ -1,5 +1,6 @@
 export * from './chunker';
 export * from './ingestion';
+export * from './inspection';
 export * from './intake';
 export * from './rasterizer';
 export * from './validation';

--- a/lib/materials/index.ts
+++ b/lib/materials/index.ts
@@ -3,6 +3,7 @@ export * from './deletion';
 export * from './ingestion';
 export * from './inspection';
 export * from './intake';
+export * from './purge';
 export * from './rasterizer';
 export * from './validation';
 export * from './vision';

--- a/lib/materials/index.ts
+++ b/lib/materials/index.ts
@@ -1,4 +1,5 @@
 export * from './chunker';
+export * from './deletion';
 export * from './ingestion';
 export * from './inspection';
 export * from './intake';

--- a/lib/materials/inspection.test.ts
+++ b/lib/materials/inspection.test.ts
@@ -1,0 +1,312 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Material, MaterialChunk } from '@/lib/db/schema';
+import { ChatbotError } from '@/lib/errors';
+import {
+  inspectMaterialContent,
+  inspectMaterialInputSchema,
+  synthesizeMaterialContent,
+} from './inspection';
+
+const mockGetMaterialById = vi.fn();
+const mockGetMaterialChunksByMaterialId = vi.fn();
+
+vi.mock('@/lib/db/queries/material', () => ({
+  getMaterialById: (...args: unknown[]) => mockGetMaterialById(...args),
+  getMaterialChunksByMaterialId: (...args: unknown[]) => mockGetMaterialChunksByMaterialId(...args),
+}));
+
+describe('Material Content Inspection Domain Logic (lib/materials/inspection)', () => {
+  const sampleMaterial: Material = {
+    id: 'mat-100',
+    projectId: 'proj-1',
+    userId: 'user-1',
+    title: 'Lecture 1: Quantum Mechanics',
+    filename: 'lecture1.pdf',
+    fileType: 'application/pdf',
+    fileSize: 1024 * 50,
+    storagePath: 'proj-1/uuid-lecture1.pdf',
+    status: 'ready',
+    errorMessage: null,
+    metadata: { pageCount: 2, chunkCount: 3, tokenCount: 450 },
+    createdAt: new Date('2026-08-20T10:00:00.000Z'),
+    updatedAt: new Date('2026-08-20T10:05:00.000Z'),
+  };
+
+  const sampleChunks: MaterialChunk[] = [
+    {
+      id: 'chunk-1',
+      materialId: 'mat-100',
+      projectId: 'proj-1',
+      userId: 'user-1',
+      chunkIndex: 0,
+      content: '# Introduction\nQuantum mechanics is a fundamental theory in physics.',
+      tokenCount: 150,
+      embedding: null,
+      metadata: { pageNumber: 1 },
+      createdAt: new Date('2026-08-20T10:01:00.000Z'),
+    },
+    {
+      id: 'chunk-2',
+      materialId: 'mat-100',
+      projectId: 'proj-1',
+      userId: 'user-1',
+      chunkIndex: 1,
+      content: '## Superposition\nParticles can exist in linear combinations of states.',
+      tokenCount: 160,
+      embedding: null,
+      metadata: { pageNumber: 1 },
+      createdAt: new Date('2026-08-20T10:02:00.000Z'),
+    },
+    {
+      id: 'chunk-3',
+      materialId: 'mat-100',
+      projectId: 'proj-1',
+      userId: 'user-1',
+      chunkIndex: 2,
+      content: '## Entanglement\nSpooky action at a distance connects multiple quantum systems.',
+      tokenCount: 140,
+      embedding: null,
+      metadata: { pageNumber: 2 },
+      createdAt: new Date('2026-08-20T10:03:00.000Z'),
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('inspectMaterialInputSchema', () => {
+    it('validates correct input parameters', () => {
+      const valid = inspectMaterialInputSchema.safeParse({
+        materialId: 'mat-100',
+        projectId: 'proj-1',
+        userId: 'user-1',
+      });
+      expect(valid.success).toBe(true);
+      if (valid.success) {
+        expect(valid.data.materialId).toBe('mat-100');
+        expect(valid.data.projectId).toBe('proj-1');
+        expect(valid.data.userId).toBe('user-1');
+      }
+    });
+
+    it('rejects empty or whitespace-only strings', () => {
+      expect(
+        inspectMaterialInputSchema.safeParse({
+          materialId: '   ',
+          projectId: 'proj-1',
+          userId: 'user-1',
+        }).success,
+      ).toBe(false);
+
+      expect(
+        inspectMaterialInputSchema.safeParse({
+          materialId: 'mat-100',
+          projectId: '',
+          userId: 'user-1',
+        }).success,
+      ).toBe(false);
+
+      expect(
+        inspectMaterialInputSchema.safeParse({
+          materialId: 'mat-100',
+          projectId: 'proj-1',
+          userId: '  ',
+        }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe('inspectMaterialContent', () => {
+    it('successfully fetches material and returns sorted chunks and concatenated content', async () => {
+      mockGetMaterialById.mockResolvedValueOnce(sampleMaterial);
+      mockGetMaterialChunksByMaterialId.mockResolvedValueOnce(sampleChunks);
+
+      const result = await inspectMaterialContent({
+        materialId: 'mat-100',
+        projectId: 'proj-1',
+        userId: 'user-1',
+      });
+
+      expect(mockGetMaterialById).toHaveBeenCalledWith({
+        id: 'mat-100',
+      });
+      expect(mockGetMaterialChunksByMaterialId).toHaveBeenCalledWith({
+        materialId: 'mat-100',
+      });
+
+      expect(result.material).toEqual(sampleMaterial);
+      expect(result.chunks).toEqual(sampleChunks);
+      expect(result.content).toBe(
+        '# Introduction\nQuantum mechanics is a fundamental theory in physics.\n\n' +
+          '## Superposition\nParticles can exist in linear combinations of states.\n\n' +
+          '## Entanglement\nSpooky action at a distance connects multiple quantum systems.',
+      );
+    });
+
+    it('guarantees ascending chunk index order even if DB returns out of order', async () => {
+      mockGetMaterialById.mockResolvedValueOnce(sampleMaterial);
+      // Pass chunks in unordered order: [chunk-3 (idx 2), chunk-1 (idx 0), chunk-2 (idx 1)]
+      mockGetMaterialChunksByMaterialId.mockResolvedValueOnce([
+        sampleChunks[2],
+        sampleChunks[0],
+        sampleChunks[1],
+      ]);
+
+      const result = await inspectMaterialContent({
+        materialId: 'mat-100',
+        projectId: 'proj-1',
+        userId: 'user-1',
+      });
+
+      expect(result.chunks.map((c) => c.chunkIndex)).toEqual([0, 1, 2]);
+      expect(result.chunks[0].id).toBe('chunk-1');
+      expect(result.chunks[1].id).toBe('chunk-2');
+      expect(result.chunks[2].id).toBe('chunk-3');
+      expect(result.content.startsWith('# Introduction')).toBe(true);
+      expect(result.content.endsWith('multiple quantum systems.')).toBe(true);
+    });
+
+    it('handles materials with 0 chunks cleanly with empty content string', async () => {
+      mockGetMaterialById.mockResolvedValueOnce(sampleMaterial);
+      mockGetMaterialChunksByMaterialId.mockResolvedValueOnce([]);
+
+      const result = await inspectMaterialContent({
+        materialId: 'mat-100',
+        projectId: 'proj-1',
+        userId: 'user-1',
+      });
+
+      expect(result.material).toEqual(sampleMaterial);
+      expect(result.chunks).toEqual([]);
+      expect(result.content).toBe('');
+    });
+
+    it('throws bad_request error if materialId is missing or empty', async () => {
+      await expect(
+        inspectMaterialContent({
+          materialId: '',
+          projectId: 'proj-1',
+          userId: 'user-1',
+        }),
+      ).rejects.toThrow(ChatbotError);
+
+      await expect(
+        inspectMaterialContent({
+          materialId: '   ',
+          projectId: 'proj-1',
+          userId: 'user-1',
+        }),
+      ).rejects.toMatchObject({
+        type: 'bad_request',
+        surface: 'document',
+      });
+    });
+
+    it('throws bad_request error if projectId is missing or empty', async () => {
+      await expect(
+        inspectMaterialContent({
+          materialId: 'mat-100',
+          projectId: '',
+          userId: 'user-1',
+        }),
+      ).rejects.toMatchObject({
+        type: 'bad_request',
+        surface: 'document',
+      });
+    });
+
+    it('throws unauthorized error if userId is missing or empty', async () => {
+      await expect(
+        inspectMaterialContent({
+          materialId: 'mat-100',
+          projectId: 'proj-1',
+          userId: '',
+        }),
+      ).rejects.toMatchObject({
+        type: 'unauthorized',
+        surface: 'document',
+      });
+    });
+
+    it('throws not_found error when material record does not exist', async () => {
+      mockGetMaterialById.mockResolvedValueOnce(null);
+
+      await expect(
+        inspectMaterialContent({
+          materialId: 'non-existent-mat',
+          projectId: 'proj-1',
+          userId: 'user-1',
+        }),
+      ).rejects.toMatchObject({
+        type: 'not_found',
+        surface: 'document',
+      });
+    });
+
+    it('throws forbidden error when material belongs to a different user', async () => {
+      mockGetMaterialById.mockResolvedValueOnce({
+        ...sampleMaterial,
+        userId: 'other-user',
+      });
+
+      await expect(
+        inspectMaterialContent({
+          materialId: 'mat-100',
+          projectId: 'proj-1',
+          userId: 'user-1',
+        }),
+      ).rejects.toMatchObject({
+        type: 'forbidden',
+        surface: 'document',
+      });
+    });
+
+    it('throws not_found error when material belongs to a different project', async () => {
+      mockGetMaterialById.mockResolvedValueOnce({
+        ...sampleMaterial,
+        projectId: 'other-project',
+      });
+
+      await expect(
+        inspectMaterialContent({
+          materialId: 'mat-100',
+          projectId: 'proj-1',
+          userId: 'user-1',
+        }),
+      ).rejects.toMatchObject({
+        type: 'not_found',
+        surface: 'document',
+      });
+    });
+
+    it('re-throws existing ChatbotError or wraps unhandled DB query errors', async () => {
+      mockGetMaterialById.mockRejectedValueOnce(new Error('Postgres connection terminated'));
+
+      await expect(
+        inspectMaterialContent({
+          materialId: 'mat-100',
+          projectId: 'proj-1',
+          userId: 'user-1',
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('synthesizeMaterialContent', () => {
+    it('concatenates chunk contents in index order with double newline', () => {
+      const outOfOrderChunks: MaterialChunk[] = [sampleChunks[1], sampleChunks[2], sampleChunks[0]];
+
+      const content = synthesizeMaterialContent(outOfOrderChunks);
+      expect(content).toBe(
+        '# Introduction\nQuantum mechanics is a fundamental theory in physics.\n\n' +
+          '## Superposition\nParticles can exist in linear combinations of states.\n\n' +
+          '## Entanglement\nSpooky action at a distance connects multiple quantum systems.',
+      );
+    });
+
+    it('returns empty string for empty chunks array', () => {
+      expect(synthesizeMaterialContent([])).toBe('');
+    });
+  });
+});

--- a/lib/materials/inspection.ts
+++ b/lib/materials/inspection.ts
@@ -1,0 +1,94 @@
+import { z } from 'zod';
+import { getMaterialById, getMaterialChunksByMaterialId } from '@/lib/db/queries/material';
+import type { Material, MaterialChunk } from '@/lib/db/schema';
+import { ChatbotError } from '@/lib/errors';
+
+export const inspectMaterialInputSchema = z.object({
+  materialId: z.string().trim().min(1, 'A valid material ID is required.'),
+  projectId: z.string().trim().min(1, 'A valid project ID is required.'),
+  userId: z.string().trim().min(1, 'You need to sign in to view this document.'),
+});
+
+export type InspectMaterialInput = z.infer<typeof inspectMaterialInputSchema>;
+
+export type MaterialInspectionResult = {
+  material: Material;
+  chunks: MaterialChunk[];
+  content: string;
+};
+
+/**
+ * Pure helper function to concatenate chunk contents in ascending index order.
+ */
+export function synthesizeMaterialContent(chunks: MaterialChunk[]): string {
+  if (!chunks || chunks.length === 0) {
+    return '';
+  }
+
+  return [...chunks]
+    .sort((a, b) => a.chunkIndex - b.chunkIndex)
+    .map((chunk) => chunk.content)
+    .join('\n\n');
+}
+
+/**
+ * Core Material Content inspection domain function.
+ * Loads a material record, validates project and user ownership,
+ * fetches all associated vector chunks in ascending index order,
+ * and synthesizes the concatenated text content for preview and inspection.
+ */
+export async function inspectMaterialContent(
+  input: InspectMaterialInput,
+): Promise<MaterialInspectionResult> {
+  const parseResult = inspectMaterialInputSchema.safeParse(input);
+  if (!parseResult.success) {
+    const firstIssue = parseResult.error.issues[0];
+    if (firstIssue?.path[0] === 'userId') {
+      throw new ChatbotError(
+        'unauthorized:document',
+        firstIssue.message || 'You need to sign in to view this document.',
+      );
+    }
+    throw new ChatbotError(
+      'bad_request:document',
+      firstIssue?.message || 'Invalid inspection request parameters.',
+    );
+  }
+
+  const { materialId, projectId, userId } = parseResult.data;
+
+  // 1. Fetch material record
+  const material = await getMaterialById({ id: materialId });
+
+  if (!material) {
+    throw new ChatbotError('not_found:document', 'Material not found.');
+  }
+
+  // 2. Validate user and project ownership scoping
+  if (material.userId !== userId) {
+    throw new ChatbotError('forbidden:document', 'This document belongs to another user.');
+  }
+
+  if (material.projectId !== projectId) {
+    throw new ChatbotError(
+      'not_found:document',
+      'Material does not belong to the specified project.',
+    );
+  }
+
+  // 3. Load associated chunks in ascending chunk index order
+  const rawChunks = await getMaterialChunksByMaterialId({
+    materialId,
+  });
+
+  const chunks = [...rawChunks].sort((a, b) => a.chunkIndex - b.chunkIndex);
+
+  // 4. Synthesize full concatenated content
+  const content = chunks.map((chunk) => chunk.content).join('\n\n');
+
+  return {
+    material,
+    chunks,
+    content,
+  };
+}

--- a/lib/materials/intake.test.ts
+++ b/lib/materials/intake.test.ts
@@ -1,0 +1,493 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatbotError } from '@/lib/errors';
+import type { StorageDriver } from '@/lib/storage';
+import { LocalStorageDriver, resetStorageDriver } from '@/lib/storage';
+import { inferMaterialFileType, intakeMaterial, sanitizeFilename } from './intake';
+import { MAX_MATERIAL_FILE_SIZE } from './validation';
+
+// Mock DB queries
+const mockCreateMaterial = vi.fn();
+vi.mock('@/lib/db/queries/material', () => ({
+  createMaterial: (...args: unknown[]) => mockCreateMaterial(...args),
+}));
+
+// Mock Queue
+const mockSendIngestJob = vi.fn();
+vi.mock('@/lib/queue', () => ({
+  sendIngestJob: (...args: unknown[]) => mockSendIngestJob(...args),
+}));
+
+describe('Material Intake Domain Logic', () => {
+  const defaultProjectId = '11111111-1111-1111-1111-111111111111';
+  const defaultUserId = '22222222-2222-2222-2222-222222222222';
+
+  let mockUpload: ReturnType<typeof vi.fn>;
+  let mockDownload: ReturnType<typeof vi.fn>;
+  let mockDelete: ReturnType<typeof vi.fn>;
+  let mockGetUrl: ReturnType<typeof vi.fn>;
+  let mockStorage: StorageDriver;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStorageDriver();
+
+    mockUpload = vi.fn().mockResolvedValue({ path: 'uploaded-path', size: 123 });
+    mockDownload = vi.fn().mockResolvedValue(Buffer.from('content'));
+    mockDelete = vi.fn().mockResolvedValue(undefined);
+    mockGetUrl = vi.fn().mockResolvedValue('file://uploaded-path');
+
+    mockStorage = {
+      upload: mockUpload,
+      download: mockDownload,
+      delete: mockDelete,
+      getUrl: mockGetUrl,
+    } as unknown as StorageDriver;
+
+    mockCreateMaterial.mockImplementation(async (params) => ({
+      id: 'mat-uuid-1234',
+      projectId: params.projectId,
+      userId: params.userId,
+      title: params.title,
+      filename: params.filename,
+      fileType: params.fileType,
+      fileSize: params.fileSize || 0,
+      storagePath: params.storagePath,
+      status: 'pending',
+      errorMessage: null,
+      metadata: params.metadata || {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }));
+
+    mockSendIngestJob.mockResolvedValue('job-123');
+  });
+
+  describe('sanitizeFilename', () => {
+    it('preserves clean standard filenames', () => {
+      expect(sanitizeFilename('lecture_notes.pdf')).toBe('lecture_notes.pdf');
+      expect(sanitizeFilename('chapter-1.md')).toBe('chapter-1.md');
+      expect(sanitizeFilename('diagram.png')).toBe('diagram.png');
+    });
+
+    it('sanitizes spaces, special characters, and multiple symbols', () => {
+      expect(sanitizeFilename('My Lecture Notes (Draft #1)!.pdf')).toBe(
+        'My_Lecture_Notes_Draft_1.pdf',
+      );
+      expect(sanitizeFilename('symbols & * % @ test.txt')).toBe('symbols_test.txt');
+    });
+
+    it('strips directory traversal paths', () => {
+      expect(sanitizeFilename('../../etc/passwd.txt')).toBe('passwd.txt');
+      expect(sanitizeFilename('..\\..\\windows\\system32\\cmd.pdf')).toBe('cmd.pdf');
+    });
+
+    it('falls back gracefully on empty or symbol-only names', () => {
+      expect(sanitizeFilename('???!!!')).toBe('material');
+      expect(sanitizeFilename('...')).toBe('material');
+      expect(sanitizeFilename('')).toBe('material');
+      expect(sanitizeFilename('***.pdf')).toBe('material.pdf');
+    });
+  });
+
+  describe('inferMaterialFileType', () => {
+    it('infers MIME types from known extensions', () => {
+      expect(inferMaterialFileType('doc.pdf')).toBe('application/pdf');
+      expect(inferMaterialFileType('notes.md')).toBe('text/markdown');
+      expect(inferMaterialFileType('notes.markdown')).toBe('text/markdown');
+      expect(inferMaterialFileType('readme.txt')).toBe('text/plain');
+      expect(inferMaterialFileType('photo.png')).toBe('image/png');
+      expect(inferMaterialFileType('photo.jpg')).toBe('image/jpeg');
+      expect(inferMaterialFileType('photo.jpeg')).toBe('image/jpeg');
+      expect(inferMaterialFileType('image.webp')).toBe('image/webp');
+      expect(inferMaterialFileType('animation.gif')).toBe('image/gif');
+      expect(inferMaterialFileType('scan.tiff')).toBe('image/tiff');
+      expect(inferMaterialFileType('modern.avif')).toBe('image/avif');
+    });
+
+    it('prioritizes explicit valid provided type over default', () => {
+      expect(inferMaterialFileType('file.custom', 'application/pdf')).toBe('application/pdf');
+      expect(inferMaterialFileType('file.md', 'text/x-markdown')).toBe('text/x-markdown');
+    });
+
+    it('overrides generic application/octet-stream if extension is recognized', () => {
+      expect(inferMaterialFileType('notes.md', 'application/octet-stream')).toBe('text/markdown');
+      expect(inferMaterialFileType('document.pdf', 'application/octet-stream')).toBe(
+        'application/pdf',
+      );
+    });
+  });
+
+  describe('File Validation Constraints', () => {
+    it('accepts valid PDF, Markdown, text, and supported image formats', async () => {
+      const validFiles = [
+        new File(['%PDF-1.4'], 'calculus.pdf', { type: 'application/pdf' }),
+        new File(['# Topic'], 'notes.md', { type: 'text/markdown' }),
+        new File(['plain text'], 'doc.txt', { type: 'text/plain' }),
+        new File(['img-data'], 'diagram.png', { type: 'image/png' }),
+        new File(['img-data'], 'photo.jpg', { type: 'image/jpeg' }),
+        new File(['img-data'], 'graphic.webp', { type: 'image/webp' }),
+      ];
+
+      for (const file of validFiles) {
+        const result = await intakeMaterial(
+          {
+            projectId: defaultProjectId,
+            userId: defaultUserId,
+            file,
+          },
+          { storageDriver: mockStorage },
+        );
+
+        expect(result.status).toBe('pending');
+        expect(result.filename).toBe(file.name);
+      }
+    });
+
+    it('rejects unsupported file extensions and MIME types with standard domain error', async () => {
+      const invalidFiles = [
+        new File(['binary'], 'malware.exe', { type: 'application/x-msdownload' }),
+        new File(['archive'], 'bundle.zip', { type: 'application/zip' }),
+        new File(['script'], 'run.sh', { type: 'application/x-sh' }),
+        new File(['video'], 'movie.mp4', { type: 'video/mp4' }),
+      ];
+
+      for (const file of invalidFiles) {
+        await expect(
+          intakeMaterial(
+            {
+              projectId: defaultProjectId,
+              userId: defaultUserId,
+              file,
+            },
+            { storageDriver: mockStorage },
+          ),
+        ).rejects.toThrow(ChatbotError);
+      }
+
+      expect(mockUpload).not.toHaveBeenCalled();
+      expect(mockCreateMaterial).not.toHaveBeenCalled();
+      expect(mockSendIngestJob).not.toHaveBeenCalled();
+    });
+
+    it('rejects files exceeding 25MB without creating storage or database entries', async () => {
+      const oversizedFile = new File(['content'], 'giant-book.pdf', {
+        type: 'application/pdf',
+      });
+      Object.defineProperty(oversizedFile, 'size', { value: MAX_MATERIAL_FILE_SIZE + 1 });
+
+      await expect(
+        intakeMaterial(
+          {
+            projectId: defaultProjectId,
+            userId: defaultUserId,
+            file: oversizedFile,
+          },
+          { storageDriver: mockStorage },
+        ),
+      ).rejects.toThrow(ChatbotError);
+
+      expect(mockUpload).not.toHaveBeenCalled();
+      expect(mockCreateMaterial).not.toHaveBeenCalled();
+      expect(mockSendIngestJob).not.toHaveBeenCalled();
+    });
+
+    it('rejects missing or empty file payloads', async () => {
+      await expect(
+        intakeMaterial(
+          {
+            projectId: defaultProjectId,
+            userId: defaultUserId,
+            file: null as unknown as File,
+          },
+          { storageDriver: mockStorage },
+        ),
+      ).rejects.toThrow(ChatbotError);
+
+      expect(mockUpload).not.toHaveBeenCalled();
+      expect(mockCreateMaterial).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Buffer & Descriptor Payload Support', () => {
+    it('accepts raw Buffer payloads with descriptor metadata', async () => {
+      const buffer = Buffer.from('# Buffer Title\n\nContent from CLI.');
+      const result = await intakeMaterial(
+        {
+          projectId: defaultProjectId,
+          userId: defaultUserId,
+          file: {
+            name: 'buffer-note.md',
+            data: buffer,
+            type: 'text/markdown',
+            size: buffer.length,
+          },
+          title: 'Custom Title Buffer',
+        },
+        { storageDriver: mockStorage },
+      );
+
+      expect(result.id).toBe('mat-uuid-1234');
+      expect(result.title).toBe('Custom Title Buffer');
+      expect(result.filename).toBe('buffer-note.md');
+      expect(result.fileType).toBe('text/markdown');
+      expect(result.fileSize).toBe(buffer.length);
+
+      expect(mockUpload).toHaveBeenCalledWith(
+        expect.stringMatching(new RegExp(`^${defaultProjectId}/[0-9a-f-]+-buffer-note\\.md$`)),
+        buffer,
+        'text/markdown',
+      );
+      expect(result.status).toBe('pending');
+      expect(mockCreateMaterial).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: defaultProjectId,
+          userId: defaultUserId,
+          title: 'Custom Title Buffer',
+          filename: 'buffer-note.md',
+          fileType: 'text/markdown',
+          fileSize: buffer.length,
+        }),
+      );
+      expect(mockSendIngestJob).toHaveBeenCalledWith(
+        expect.objectContaining({
+          materialId: 'mat-uuid-1234',
+          projectId: defaultProjectId,
+          userId: defaultUserId,
+          fileType: 'text/markdown',
+        }),
+      );
+    });
+
+    it('accepts Uint8Array payloads and computes size automatically', async () => {
+      const uint8 = new Uint8Array([1, 2, 3, 4, 5]);
+      const result = await intakeMaterial(
+        {
+          projectId: defaultProjectId,
+          userId: defaultUserId,
+          file: {
+            filename: 'binary-image.png',
+            buffer: uint8,
+          },
+        },
+        { storageDriver: mockStorage },
+      );
+
+      expect(result.filename).toBe('binary-image.png');
+      expect(result.fileType).toBe('image/png');
+      expect(result.fileSize).toBe(5);
+      expect(mockUpload).toHaveBeenCalled();
+    });
+
+    it('accepts string data in descriptor payload', async () => {
+      const stringData = 'Simple plain text document content';
+      const result = await intakeMaterial(
+        {
+          projectId: defaultProjectId,
+          userId: defaultUserId,
+          file: {
+            name: 'notes.txt',
+            data: stringData,
+          },
+        },
+        { storageDriver: mockStorage },
+      );
+
+      expect(result.filename).toBe('notes.txt');
+      expect(result.fileType).toBe('text/plain');
+      expect(result.fileSize).toBe(Buffer.byteLength(stringData));
+    });
+
+    it('accepts Blob in descriptor payload and resolves size correctly', async () => {
+      const blob = new Blob(['blob content for test'], { type: 'text/markdown' });
+      const result = await intakeMaterial(
+        {
+          projectId: defaultProjectId,
+          userId: defaultUserId,
+          file: {
+            name: 'blob-note.md',
+            data: blob,
+          },
+        },
+        { storageDriver: mockStorage },
+      );
+
+      expect(result.filename).toBe('blob-note.md');
+      expect(result.fileType).toBe('text/markdown');
+      expect(result.fileSize).toBe(blob.size);
+    });
+
+    it('rejects disallowed file extensions even when spoofed with valid MIME type', async () => {
+      await expect(
+        intakeMaterial(
+          {
+            projectId: defaultProjectId,
+            userId: defaultUserId,
+            file: {
+              name: 'malware.exe',
+              data: Buffer.from('fake image'),
+              type: 'image/png',
+            },
+          },
+          { storageDriver: mockStorage },
+        ),
+      ).rejects.toThrow(ChatbotError);
+
+      expect(mockUpload).not.toHaveBeenCalled();
+      expect(mockCreateMaterial).not.toHaveBeenCalled();
+    });
+
+    it('rejects oversized Blob in descriptor payload', async () => {
+      const hugeBlob = new Blob(['x'], { type: 'application/pdf' });
+      Object.defineProperty(hugeBlob, 'size', { value: MAX_MATERIAL_FILE_SIZE + 100 });
+
+      await expect(
+        intakeMaterial(
+          {
+            projectId: defaultProjectId,
+            userId: defaultUserId,
+            file: {
+              name: 'giant.pdf',
+              data: hugeBlob,
+            },
+          },
+          { storageDriver: mockStorage },
+        ),
+      ).rejects.toThrow(ChatbotError);
+    });
+  });
+
+  describe('Storage Upload & Unique Path Generation', () => {
+    it('uploads to storage with project prefix, unique UUID, and sanitized filename', async () => {
+      const file = new File(['sample'], 'Complex Name (V2) [Final].pdf', {
+        type: 'application/pdf',
+      });
+
+      const result = await intakeMaterial(
+        {
+          projectId: defaultProjectId,
+          userId: defaultUserId,
+          file,
+        },
+        { storageDriver: mockStorage },
+      );
+
+      expect(mockUpload).toHaveBeenCalledWith(
+        expect.stringMatching(
+          new RegExp(`^${defaultProjectId}/[0-9a-f-]{36}-Complex_Name_V2_Final\\.pdf$`),
+        ),
+        file,
+        'application/pdf',
+      );
+      expect(result.storagePath).toMatch(
+        new RegExp(`^${defaultProjectId}/[0-9a-f-]{36}-Complex_Name_V2_Final\\.pdf$`),
+      );
+    });
+  });
+
+  describe('Metadata & Title Handling', () => {
+    it('defaults title to filename when title is not provided or empty', async () => {
+      const file = new File(['content'], 'syllabus.pdf', { type: 'application/pdf' });
+      const result = await intakeMaterial(
+        {
+          projectId: defaultProjectId,
+          userId: defaultUserId,
+          file,
+          title: '   ',
+        },
+        { storageDriver: mockStorage },
+      );
+
+      expect(result.title).toBe('syllabus.pdf');
+    });
+
+    it('merges custom metadata with intake lifecycle metadata', async () => {
+      const file = new File(['notes'], 'lecture.md', { type: 'text/markdown' });
+      await intakeMaterial(
+        {
+          projectId: defaultProjectId,
+          userId: defaultUserId,
+          file,
+          metadata: {
+            course: 'CS101',
+            week: 3,
+          },
+        },
+        { storageDriver: mockStorage },
+      );
+
+      expect(mockCreateMaterial).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            course: 'CS101',
+            week: 3,
+            intake: expect.objectContaining({
+              originalFilename: 'lecture.md',
+              sanitizedFilename: 'lecture.md',
+            }),
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('Rollback & Storage Cleanup on Failure', () => {
+    it('cleans up uploaded storage file if database insert fails', async () => {
+      mockCreateMaterial.mockRejectedValueOnce(new Error('Database connection failed'));
+
+      const file = new File(['test'], 'doc.pdf', { type: 'application/pdf' });
+
+      await expect(
+        intakeMaterial(
+          {
+            projectId: defaultProjectId,
+            userId: defaultUserId,
+            file,
+          },
+          { storageDriver: mockStorage },
+        ),
+      ).rejects.toThrow('Database connection failed');
+
+      expect(mockUpload).toHaveBeenCalled();
+      expect(mockDelete).toHaveBeenCalledWith(
+        expect.stringMatching(new RegExp(`^${defaultProjectId}/`)),
+      );
+      expect(mockSendIngestJob).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('In-Process Integration with LocalStorageDriver', () => {
+    it('exercises intake flow end-to-end using real LocalStorageDriver and DB mock', async () => {
+      const localDriver = new LocalStorageDriver(`/tmp/test-storage-intake-${Date.now()}`);
+      const uploadSpy = vi.spyOn(localDriver, 'upload');
+
+      const file = new File(['# Real Local Content'], 'local-test.md', {
+        type: 'text/markdown',
+      });
+
+      const material = await intakeMaterial(
+        {
+          projectId: defaultProjectId,
+          userId: defaultUserId,
+          file,
+          title: 'Local Driver Test',
+        },
+        { storageDriver: localDriver },
+      );
+
+      expect(material.id).toBe('mat-uuid-1234');
+      expect(material.status).toBe('pending');
+      expect(uploadSpy).toHaveBeenCalled();
+      expect(mockCreateMaterial).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Local Driver Test',
+          filename: 'local-test.md',
+        }),
+      );
+      expect(mockSendIngestJob).toHaveBeenCalledWith(
+        expect.objectContaining({
+          materialId: 'mat-uuid-1234',
+        }),
+      );
+    });
+  });
+});

--- a/lib/materials/intake.ts
+++ b/lib/materials/intake.ts
@@ -1,0 +1,248 @@
+import { createMaterial } from '@/lib/db/queries/material';
+import type { Material } from '@/lib/db/schema';
+import { ChatbotError } from '@/lib/errors';
+import { type MaterialIngestJobData, sendIngestJob } from '@/lib/queue';
+import { getStorageDriver, type StorageDriver } from '@/lib/storage';
+import { getFileExtension, inferMaterialFileType, validateMaterialFile } from './validation';
+
+export type MaterialBufferPayload = {
+  name?: string;
+  data?: Buffer | Uint8Array | ArrayBuffer | Blob | string;
+  type?: string;
+  size?: number;
+  filename?: string;
+  buffer?: Buffer | Uint8Array | ArrayBuffer | Blob | string;
+  fileType?: string;
+  fileSize?: number;
+};
+
+export type MaterialIntakePayload = File | MaterialBufferPayload;
+
+export type IntakeMaterialInput = {
+  projectId: string;
+  userId: string;
+  file: MaterialIntakePayload;
+  title?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type IntakeMaterialOptions = {
+  storageDriver?: StorageDriver;
+  sendJob?: (jobData: MaterialIngestJobData) => Promise<string | null>;
+};
+
+export type IntakeMaterialResult = Material;
+
+export { inferMaterialFileType };
+
+/**
+ * Strips path traversal sequences, replaces special characters with underscores,
+ * and ensures a safe, non-empty filename for storage.
+ */
+export function sanitizeFilename(filename: string): string {
+  if (!filename || typeof filename !== 'string') {
+    return 'material';
+  }
+
+  // Strip path segments across POSIX and Windows separators
+  const basename = filename.replace(/^.*[\\/]/, '').trim();
+  const ext = getFileExtension(basename);
+  const nameWithoutExt = ext ? basename.slice(0, -ext.length) : basename;
+
+  const cleanName = nameWithoutExt
+    .replace(/[^a-zA-Z0-9._-]/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^[._-]+|[._-]+$/g, '');
+
+  let cleanExt = ext.replace(/[^a-zA-Z0-9.]/g, '');
+  if (cleanExt === '.') {
+    cleanExt = '';
+  }
+
+  const finalName = cleanName || 'material';
+  return `${finalName}${cleanExt}`;
+}
+
+type NormalizedPayload = {
+  name: string;
+  size: number;
+  fileType: string;
+  data: Buffer | Uint8Array | Blob | string;
+};
+
+function isWebFile(payload: unknown): payload is File {
+  if (typeof File !== 'undefined' && payload instanceof File) {
+    return true;
+  }
+  return (
+    typeof payload === 'object' &&
+    payload !== null &&
+    'name' in payload &&
+    'size' in payload &&
+    typeof (payload as File).arrayBuffer === 'function'
+  );
+}
+
+function normalizeWebFile(file: File): NormalizedPayload {
+  const name = file.name || '';
+  if (!name.trim()) {
+    throw new ChatbotError('bad_request:document', 'A valid file with filename is required.');
+  }
+
+  return {
+    name,
+    size: file.size,
+    fileType: inferMaterialFileType(name, file.type),
+    data: file,
+  };
+}
+
+function resolvePayloadSize(
+  rawData: unknown,
+  explicitSize?: number,
+  fallbackSize?: number,
+): number {
+  if (typeof explicitSize === 'number') {
+    return explicitSize;
+  }
+  if (typeof fallbackSize === 'number') {
+    return fallbackSize;
+  }
+  if (Buffer.isBuffer(rawData)) {
+    return rawData.length;
+  }
+  if (rawData instanceof Uint8Array) {
+    return rawData.byteLength;
+  }
+  if (typeof rawData === 'string') {
+    return Buffer.byteLength(rawData, 'utf-8');
+  }
+  if (rawData && typeof (rawData as Blob).size === 'number') {
+    return (rawData as Blob).size;
+  }
+  if (rawData && typeof (rawData as ArrayBuffer).byteLength === 'number') {
+    return (rawData as ArrayBuffer).byteLength;
+  }
+  return 0;
+}
+
+function normalizeDescriptor(descriptor: MaterialBufferPayload): NormalizedPayload {
+  const name = descriptor.name || descriptor.filename || '';
+  if (!name.trim()) {
+    throw new ChatbotError('bad_request:document', 'A valid file with filename is required.');
+  }
+
+  const rawData = descriptor.data ?? descriptor.buffer;
+  if (rawData === undefined || rawData === null) {
+    throw new ChatbotError('bad_request:document', 'A valid file payload data is required.');
+  }
+
+  const size = resolvePayloadSize(rawData, descriptor.size, descriptor.fileSize);
+  const providedType = descriptor.type || descriptor.fileType;
+  const fileType = inferMaterialFileType(name, providedType);
+
+  const normalizedData: Buffer | Uint8Array | Blob | string =
+    rawData instanceof ArrayBuffer ? Buffer.from(rawData) : rawData;
+
+  return {
+    name,
+    size,
+    fileType,
+    data: normalizedData,
+  };
+}
+
+function normalizeIntakePayload(payload: MaterialIntakePayload): NormalizedPayload {
+  if (!payload || typeof payload !== 'object') {
+    throw new ChatbotError('bad_request:document', 'A valid file payload is required.');
+  }
+
+  if (isWebFile(payload)) {
+    return normalizeWebFile(payload);
+  }
+
+  return normalizeDescriptor(payload as MaterialBufferPayload);
+}
+
+/**
+ * Core Material Intake domain function.
+ * Validates uploaded files/buffers, uploads to storage driver under a unique path,
+ * persists the pending material database record, and enqueues background ingestion.
+ */
+export async function intakeMaterial(
+  input: IntakeMaterialInput,
+  options?: IntakeMaterialOptions,
+): Promise<IntakeMaterialResult> {
+  const { projectId, userId, file, title, metadata = {} } = input;
+
+  if (!projectId || !userId) {
+    throw new ChatbotError('bad_request:document', 'Project ID and User ID are required.');
+  }
+
+  // 1. Normalize and validate payload
+  const normalized = normalizeIntakePayload(file);
+  const validation = validateMaterialFile({
+    name: normalized.name,
+    size: normalized.size,
+    type: normalized.fileType,
+  });
+
+  if (!validation.valid) {
+    throw new ChatbotError('bad_request:document', validation.error);
+  }
+
+  // 2. Upload to storage with unique path prefix and sanitized filename
+  const sanitized = sanitizeFilename(normalized.name);
+  const uniqueId = crypto.randomUUID();
+  const storagePath = `${projectId}/${uniqueId}-${sanitized}`;
+  const storageDriver = options?.storageDriver ?? getStorageDriver();
+
+  await storageDriver.upload(storagePath, normalized.data, normalized.fileType);
+
+  // 3. Persist pending material database record (with rollback on DB failure)
+  const resolvedTitle =
+    typeof title === 'string' && title.trim().length > 0 ? title.trim() : normalized.name;
+  let material: Material;
+
+  try {
+    material = await createMaterial({
+      projectId,
+      userId,
+      title: resolvedTitle,
+      filename: normalized.name,
+      fileType: normalized.fileType,
+      fileSize: normalized.size,
+      storagePath,
+      metadata: {
+        ...metadata,
+        intake: {
+          uploadedAt: new Date().toISOString(),
+          originalFilename: normalized.name,
+          sanitizedFilename: sanitized,
+        },
+      },
+    });
+  } catch (dbError) {
+    try {
+      await storageDriver.delete(storagePath);
+    } catch (cleanupError) {
+      console.error(
+        `Failed to cleanup storage blob "${storagePath}" after database error:`,
+        cleanupError,
+      );
+    }
+    throw dbError;
+  }
+
+  // 4. Dispatch background ingestion job
+  const sendJob = options?.sendJob ?? sendIngestJob;
+  await sendJob({
+    materialId: material.id,
+    projectId,
+    userId,
+    storagePath,
+    fileType: normalized.fileType,
+  });
+
+  return material;
+}

--- a/lib/materials/purge.test.ts
+++ b/lib/materials/purge.test.ts
@@ -1,0 +1,304 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatbotError } from '@/lib/errors';
+import type { StorageDriver } from '@/lib/storage';
+import { LocalStorageDriver, resetStorageDriver } from '@/lib/storage';
+import { purgeProjectMaterialsStorage } from './purge';
+
+// Mock DB queries
+const mockGetMaterialsByProjectId = vi.fn();
+
+vi.mock('@/lib/db/queries/material', () => ({
+  getMaterialsByProjectId: (...args: unknown[]) => mockGetMaterialsByProjectId(...args),
+}));
+
+describe('Project Materials Storage Purge Domain Logic', () => {
+  const defaultProjectId = '11111111-1111-1111-1111-111111111111';
+  const defaultUserId = '22222222-2222-2222-2222-222222222222';
+
+  const sampleMaterials = [
+    {
+      id: 'mat-1',
+      projectId: defaultProjectId,
+      userId: defaultUserId,
+      title: 'Lecture 1',
+      filename: 'lecture1.pdf',
+      fileType: 'application/pdf',
+      fileSize: 1024,
+      storagePath: `${defaultProjectId}/lecture1.pdf`,
+      status: 'ready' as const,
+      errorMessage: null,
+      metadata: {},
+      createdAt: new Date('2026-08-20T10:00:00.000Z'),
+      updatedAt: new Date('2026-08-20T10:05:00.000Z'),
+    },
+    {
+      id: 'mat-2',
+      projectId: defaultProjectId,
+      userId: defaultUserId,
+      title: 'Lecture 2',
+      filename: 'lecture2.pdf',
+      fileType: 'application/pdf',
+      fileSize: 2048,
+      storagePath: `${defaultProjectId}/lecture2.pdf`,
+      status: 'ready' as const,
+      errorMessage: null,
+      metadata: {},
+      createdAt: new Date('2026-08-20T11:00:00.000Z'),
+      updatedAt: new Date('2026-08-20T11:05:00.000Z'),
+    },
+    {
+      id: 'mat-3',
+      projectId: defaultProjectId,
+      userId: defaultUserId,
+      title: 'Notes',
+      filename: 'notes.md',
+      fileType: 'text/markdown',
+      fileSize: 512,
+      storagePath: `${defaultProjectId}/notes.md`,
+      status: 'ready' as const,
+      errorMessage: null,
+      metadata: {},
+      createdAt: new Date('2026-08-20T12:00:00.000Z'),
+      updatedAt: new Date('2026-08-20T12:05:00.000Z'),
+    },
+  ];
+
+  let mockDeleteBlob: ReturnType<typeof vi.fn>;
+  let mockStorage: StorageDriver;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStorageDriver();
+
+    mockDeleteBlob = vi.fn().mockResolvedValue(undefined);
+    mockStorage = {
+      upload: vi.fn(),
+      download: vi.fn(),
+      delete: mockDeleteBlob,
+    } as unknown as StorageDriver;
+
+    mockGetMaterialsByProjectId.mockResolvedValue([...sampleMaterials]);
+  });
+
+  describe('Successful Multi-File Purging Flow', () => {
+    it('retrieves materials and deletes all physical storage blobs', async () => {
+      const result = await purgeProjectMaterialsStorage(
+        {
+          projectId: defaultProjectId,
+          userId: defaultUserId,
+        },
+        { storageDriver: mockStorage },
+      );
+
+      expect(result).toEqual({
+        purgedCount: 3,
+        totalMaterials: 3,
+      });
+
+      expect(mockGetMaterialsByProjectId).toHaveBeenCalledWith({
+        projectId: defaultProjectId,
+        userId: defaultUserId,
+      });
+
+      expect(mockDeleteBlob).toHaveBeenCalledTimes(3);
+      expect(mockDeleteBlob).toHaveBeenCalledWith(`${defaultProjectId}/lecture1.pdf`);
+      expect(mockDeleteBlob).toHaveBeenCalledWith(`${defaultProjectId}/lecture2.pdf`);
+      expect(mockDeleteBlob).toHaveBeenCalledWith(`${defaultProjectId}/notes.md`);
+    });
+
+    it('works when userId is omitted (project-level purge)', async () => {
+      const result = await purgeProjectMaterialsStorage(
+        {
+          projectId: defaultProjectId,
+        },
+        { storageDriver: mockStorage },
+      );
+
+      expect(result.purgedCount).toBe(3);
+      expect(mockGetMaterialsByProjectId).toHaveBeenCalledWith({
+        projectId: defaultProjectId,
+        userId: undefined,
+      });
+      expect(mockDeleteBlob).toHaveBeenCalledTimes(3);
+    });
+
+    it('returns purgedCount: 0 when project has no materials', async () => {
+      mockGetMaterialsByProjectId.mockResolvedValueOnce([]);
+
+      const result = await purgeProjectMaterialsStorage(
+        {
+          projectId: defaultProjectId,
+          userId: defaultUserId,
+        },
+        { storageDriver: mockStorage },
+      );
+
+      expect(result).toEqual({
+        purgedCount: 0,
+        totalMaterials: 0,
+      });
+      expect(mockDeleteBlob).not.toHaveBeenCalled();
+    });
+
+    it('skips materials with empty or missing storagePath', async () => {
+      mockGetMaterialsByProjectId.mockResolvedValueOnce([
+        { ...sampleMaterials[0], storagePath: '' },
+        { ...sampleMaterials[1], storagePath: '   ' },
+        { ...sampleMaterials[2], storagePath: `${defaultProjectId}/notes.md` },
+      ]);
+
+      const result = await purgeProjectMaterialsStorage(
+        {
+          projectId: defaultProjectId,
+          userId: defaultUserId,
+        },
+        { storageDriver: mockStorage },
+      );
+
+      expect(result).toEqual({
+        purgedCount: 1,
+        totalMaterials: 3,
+      });
+      expect(mockDeleteBlob).toHaveBeenCalledTimes(1);
+      expect(mockDeleteBlob).toHaveBeenCalledWith(`${defaultProjectId}/notes.md`);
+    });
+  });
+
+  describe('Non-Fatal Error Handling & Fault Tolerance', () => {
+    it('continues deleting remaining files and logs warnings when individual storage deletions fail', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {
+        // Suppress console warning in test output
+      });
+
+      // Fail the 2nd file, succeed for 1st and 3rd
+      mockDeleteBlob.mockImplementation((filePath: string) => {
+        if (filePath.includes('lecture2.pdf')) {
+          return Promise.reject(new Error('Blob not found on storage remote'));
+        }
+        return Promise.resolve();
+      });
+
+      const result = await purgeProjectMaterialsStorage(
+        {
+          projectId: defaultProjectId,
+          userId: defaultUserId,
+        },
+        { storageDriver: mockStorage },
+      );
+
+      expect(result).toEqual({
+        purgedCount: 2,
+        totalMaterials: 3,
+      });
+
+      expect(mockDeleteBlob).toHaveBeenCalledTimes(3);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to purge physical storage blob'),
+        expect.any(Error),
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it('tolerates when all storage deletions throw errors', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {
+        // Suppress console warning in test output
+      });
+
+      mockDeleteBlob.mockRejectedValue(new Error('Storage service unavailable'));
+
+      const result = await purgeProjectMaterialsStorage(
+        {
+          projectId: defaultProjectId,
+          userId: defaultUserId,
+        },
+        { storageDriver: mockStorage },
+      );
+
+      expect(result).toEqual({
+        purgedCount: 0,
+        totalMaterials: 3,
+      });
+
+      expect(mockDeleteBlob).toHaveBeenCalledTimes(3);
+      expect(warnSpy).toHaveBeenCalledTimes(3);
+
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('Input Validation Constraints', () => {
+    it('throws bad_request ChatbotError when projectId is missing or empty', async () => {
+      await expect(
+        purgeProjectMaterialsStorage(
+          {
+            projectId: '   ',
+          },
+          { storageDriver: mockStorage },
+        ),
+      ).rejects.toThrow(ChatbotError);
+
+      await expect(
+        purgeProjectMaterialsStorage({} as unknown as { projectId: string }, {
+          storageDriver: mockStorage,
+        }),
+      ).rejects.toThrow(ChatbotError);
+
+      expect(mockGetMaterialsByProjectId).not.toHaveBeenCalled();
+      expect(mockDeleteBlob).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('In-Process Integration with LocalStorageDriver', () => {
+    it('physically purges all project files from disk and tolerates missing files', async () => {
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'test-storage-purge-'));
+      const localDriver = new LocalStorageDriver(tempDir);
+
+      try {
+        // 1. Create real files on disk
+        const path1 = `${defaultProjectId}/file1.txt`;
+        const path2 = `${defaultProjectId}/file2.txt`;
+        const path3 = `${defaultProjectId}/file3.txt`;
+
+        await localDriver.upload(path1, 'Content 1', 'text/plain');
+        await localDriver.upload(path2, 'Content 2', 'text/plain');
+        // Note: intentionally do NOT upload file3 on disk to test missing file tolerance
+
+        mockGetMaterialsByProjectId.mockResolvedValueOnce([
+          { ...sampleMaterials[0], storagePath: path1 },
+          { ...sampleMaterials[1], storagePath: path2 },
+          { ...sampleMaterials[2], storagePath: path3 },
+        ]);
+
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {
+          // Suppress warning output in test
+        });
+
+        // 2. Purge project materials storage
+        const result = await purgeProjectMaterialsStorage(
+          {
+            projectId: defaultProjectId,
+            userId: defaultUserId,
+          },
+          { storageDriver: localDriver },
+        );
+
+        // path1 and path2 exist and are deleted (succeed).
+        expect(result.totalMaterials).toBe(3);
+
+        // Verify files are no longer on disk
+        const fullDiskPath1 = path.join(tempDir, path1);
+        const fullDiskPath2 = path.join(tempDir, path2);
+        await expect(fs.stat(fullDiskPath1)).rejects.toThrow();
+        await expect(fs.stat(fullDiskPath2)).rejects.toThrow();
+
+        warnSpy.mockRestore();
+      } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/lib/materials/purge.ts
+++ b/lib/materials/purge.ts
@@ -1,0 +1,80 @@
+import { getMaterialsByProjectId } from '@/lib/db/queries/material';
+import { ChatbotError } from '@/lib/errors';
+import { getStorageDriver, type StorageDriver } from '@/lib/storage';
+
+export type PurgeProjectMaterialsInput = {
+  projectId: string;
+  userId?: string;
+};
+
+export type PurgeProjectMaterialsOptions = {
+  storageDriver?: StorageDriver;
+};
+
+export type PurgeProjectMaterialsResult = {
+  purgedCount: number;
+  totalMaterials: number;
+};
+
+/**
+ * Project Materials storage purge domain function.
+ * When an entire project is being removed, this function finds all material
+ * storage paths associated with that project and purges them from the physical
+ * storage driver with non-fatal error handling so failures on individual blobs
+ * do not abort the cascade or remaining deletions.
+ */
+export async function purgeProjectMaterialsStorage(
+  input: PurgeProjectMaterialsInput,
+  options?: PurgeProjectMaterialsOptions,
+): Promise<PurgeProjectMaterialsResult> {
+  const projectId = input?.projectId?.trim();
+
+  if (!projectId) {
+    throw new ChatbotError('bad_request:document', 'A valid project ID is required.');
+  }
+
+  const userId = input.userId?.trim() || undefined;
+
+  // 1. Retrieve all materials belonging to the project (and optionally user)
+  const materials = await getMaterialsByProjectId({
+    projectId,
+    userId,
+  });
+
+  if (!materials || materials.length === 0) {
+    return {
+      purgedCount: 0,
+      totalMaterials: 0,
+    };
+  }
+
+  const storageDriver = options?.storageDriver ?? getStorageDriver();
+
+  // 2. Filter materials that have a valid storage path
+  const materialsWithStorage = materials.filter(
+    (material) => material.storagePath && material.storagePath.trim().length > 0,
+  );
+
+  // 3. Purge physical storage blobs concurrently with non-fatal error handling
+  const deletionResults = await Promise.all(
+    materialsWithStorage.map(async (material) => {
+      try {
+        await storageDriver.delete(material.storagePath);
+        return true;
+      } catch (storageError) {
+        console.warn(
+          `Failed to purge physical storage blob at "${material.storagePath}" for project "${projectId}" (material "${material.id}"):`,
+          storageError,
+        );
+        return false;
+      }
+    }),
+  );
+
+  const purgedCount = deletionResults.filter(Boolean).length;
+
+  return {
+    purgedCount,
+    totalMaterials: materials.length,
+  };
+}

--- a/lib/materials/validation.ts
+++ b/lib/materials/validation.ts
@@ -18,31 +18,94 @@ export const ACCEPTED_FILE_EXTENSIONS = [
 
 export const ACCEPTED_FILE_TYPES_STRING = ACCEPTED_FILE_EXTENSIONS.join(',');
 
+export const EXTENSION_MIME_MAP: Record<string, string> = {
+  '.pdf': 'application/pdf',
+  '.md': 'text/markdown',
+  '.markdown': 'text/markdown',
+  '.txt': 'text/plain',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif',
+  '.bmp': 'image/bmp',
+  '.tiff': 'image/tiff',
+  '.tif': 'image/tiff',
+  '.avif': 'image/avif',
+};
+
 export type FileValidationResult = { valid: true; error?: never } | { valid: false; error: string };
 
-export function validateMaterialFile(file: File): FileValidationResult {
-  const lastDot = file.name.lastIndexOf('.');
-  const extension = lastDot >= 0 ? file.name.slice(lastDot).toLowerCase() : '';
+export type MaterialFileValidationTarget = {
+  name: string;
+  size: number;
+  type?: string;
+};
 
-  const isAcceptedExtension = ACCEPTED_FILE_EXTENSIONS.includes(extension);
-  const isAcceptedMime =
-    file.type === 'application/pdf' ||
-    file.type === 'text/markdown' ||
-    file.type === 'text/plain' ||
-    file.type === 'text/x-markdown' ||
-    file.type.startsWith('image/');
+export function getFileExtension(filename: string): string {
+  if (!filename || typeof filename !== 'string') {
+    return '';
+  }
+  const lastDot = filename.lastIndexOf('.');
+  return lastDot >= 0 ? filename.slice(lastDot).toLowerCase() : '';
+}
 
-  if (!isAcceptedExtension && !isAcceptedMime) {
+export function inferMaterialFileType(filename: string, providedType?: string): string {
+  const normProvided = providedType?.trim();
+  if (normProvided && normProvided !== 'application/octet-stream') {
+    return normProvided;
+  }
+
+  const extension = getFileExtension(filename);
+  return EXTENSION_MIME_MAP[extension] ?? normProvided ?? 'application/octet-stream';
+}
+
+function isAcceptedMimeType(fileType: string): boolean {
+  const normType = fileType.toLowerCase();
+  return (
+    normType === 'application/pdf' ||
+    normType === 'application/x-pdf' ||
+    normType === 'text/markdown' ||
+    normType === 'text/plain' ||
+    normType === 'text/x-markdown' ||
+    normType.startsWith('image/')
+  );
+}
+
+export function validateMaterialFile(
+  file: MaterialFileValidationTarget | File,
+): FileValidationResult {
+  if (!file || typeof file !== 'object' || typeof file.name !== 'string') {
     return {
       valid: false,
-      error: `Unsupported file format (${extension || file.type || 'unknown'}). Supported: PDF, Markdown, Text, Images.`,
+      error: 'A valid file payload is required.',
     };
   }
 
-  if (file.size > MAX_MATERIAL_FILE_SIZE) {
+  const extension = getFileExtension(file.name);
+  const fileType = file.type || '';
+
+  // If an extension exists, it must strictly be in the allowed extensions list
+  if (extension && !ACCEPTED_FILE_EXTENSIONS.includes(extension)) {
     return {
       valid: false,
-      error: `File size (${formatFileSize(file.size)}) exceeds the 25MB limit.`,
+      error: `Unsupported file format (${extension}). Supported: PDF, Markdown, Text, Images.`,
+    };
+  }
+
+  // If no extension is present, validate against accepted MIME types
+  if (!extension && !isAcceptedMimeType(fileType)) {
+    return {
+      valid: false,
+      error: `Unsupported file format (${fileType || 'unknown'}). Supported: PDF, Markdown, Text, Images.`,
+    };
+  }
+
+  const size = typeof file.size === 'number' ? file.size : 0;
+  if (size > MAX_MATERIAL_FILE_SIZE) {
+    return {
+      valid: false,
+      error: `File size (${formatFileSize(size)}) exceeds the 25MB limit.`,
     };
   }
 


### PR DESCRIPTION
## Summary

Consolidated implementation for epic material-lifecycle (Issue #80).
Closes #80
Closes #81
Closes #82
Closes #83
Closes #84
Closes #85
Closes #86
Closes #87
Closes #88

## Changes

- **feat(materials): Material Intake Domain Logic (#81)**: Implemented `intakeMaterial` domain function coordinating payload normalization, format/size validation, unique path storage persistence, pending database record creation, rollback safety, and background ingestion job queuing.
- **refactor(api): Material Upload Route Seam (#82)**: Refactored `POST /api/projects/[id]/materials` into a thin controller delegating to `intakeMaterial`.
- **feat(materials): Material Content Inspection Domain Logic (#83)**: Implemented `inspectMaterialContent` to load materials, verify project/user scoping, fetch ascending chunks, and synthesize preview text.
- **refactor(api): Material Preview Route Seam (#84)**: Refactored `GET /api/projects/[id]/materials/[materialId]` into a thin controller delegating to `inspectMaterialContent`.
- **feat(materials): Material Deletion Domain Logic (#85)**: Implemented `deleteMaterial` to remove database records (cascading chunk rows) and purge physical storage files with non-fatal error tolerance.
- **refactor(api): Material Deletion Route Seam (#86)**: Refactored `DELETE /api/projects/[id]/materials/[materialId]` into a thin controller delegating to `deleteMaterial`.
- **feat(materials): Project-Level Cascade Storage Purging (#87)**: Implemented `purgeProjectMaterialsStorage` to identify and delete all physical storage blobs belonging to a project with non-fatal warning tolerance.
- **feat(projects): Project Deletion Route Storage Purging (#88)**: Wired `DELETE /api/projects/[id]` to purge all project material physical storage files before cascading database records.

## Definition of Done

- [x] All acceptance criteria for #81 verified (Intake domain logic + tests)
- [x] All acceptance criteria for #82 verified (Upload route refactor + tests)
- [x] All acceptance criteria for #83 verified (Content inspection domain logic + tests)
- [x] All acceptance criteria for #84 verified (Preview route refactor + tests)
- [x] All acceptance criteria for #85 verified (Material deletion domain logic + storage cleanup + tests)
- [x] All acceptance criteria for #86 verified (Material deletion route refactor + tests)
- [x] All acceptance criteria for #87 verified (Project-level cascade storage purging domain logic + tests)
- [x] All acceptance criteria for #88 verified (Project deletion route storage purging + tests)

## Verification

- [x] `pnpm check` passes (Biome lint + TypeScript typecheck + Vitest 35 suites / 282 tests)
- [x] Architectural boundaries verified (`pnpm scan:arch`)
- [x] Subagent code reviews completed (Standards & Spec reviews passed for every ticket)