### PR TITLE
feat(auth): unify authentication and session resolution seam

### DIFF
--- a/app/api/chat/route.test.ts
+++ b/app/api/chat/route.test.ts
@@ -1,14 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatbotError } from '@/lib/errors';
 import { DELETE, POST } from './route';
 
 // Mock dependencies
-const mockGetUser = vi.fn();
-vi.mock('@/lib/supabase/server', () => ({
-  createClient: vi.fn().mockImplementation(async () => ({
-    auth: {
-      getUser: mockGetUser,
-    },
-  })),
+const mockRequireAuthUser = vi.fn();
+vi.mock('@/lib/auth/session', () => ({
+  requireAuthUser: (...args: unknown[]) => mockRequireAuthUser(...args),
 }));
 
 const mockSaveChat = vi.fn();
@@ -84,7 +81,7 @@ describe('Chat API Handler (/api/chat)', () => {
 
   describe('POST /api/chat', () => {
     it('returns 401 Unauthorized when session is unauthenticated', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+      mockRequireAuthUser.mockRejectedValueOnce(new ChatbotError('unauthorized:chat'));
 
       const request = new Request('http://localhost:3000/api/chat', {
         method: 'POST',
@@ -119,7 +116,7 @@ describe('Chat API Handler (/api/chat)', () => {
     it('creates chat and streams response when authenticated', async () => {
       const testUser = { id: 'user-uuid-123', email: 'test@example.com' };
       const projectId = '770e8400-e29b-41d4-a716-446655440000';
-      mockGetUser.mockResolvedValueOnce({ data: { user: testUser }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(testUser);
       mockGetChatById.mockResolvedValueOnce(null); // Chat does not exist yet
       mockGetProjectById.mockResolvedValueOnce({
         id: projectId,
@@ -182,7 +179,7 @@ describe('Chat API Handler (/api/chat)', () => {
 
     it('returns 400 if projectId is missing for a new chat', async () => {
       const testUser = { id: 'user-uuid-123', email: 'test@example.com' };
-      mockGetUser.mockResolvedValueOnce({ data: { user: testUser }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(testUser);
       mockGetChatById.mockResolvedValueOnce(null);
 
       const request = new Request('http://localhost:3000/api/chat', {
@@ -202,7 +199,7 @@ describe('Chat API Handler (/api/chat)', () => {
 
     it('returns 403 Forbidden if user tries to post to another user chat', async () => {
       const testUser = { id: 'user-uuid-123', email: 'test@example.com' };
-      mockGetUser.mockResolvedValueOnce({ data: { user: testUser }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(testUser);
       mockGetChatById.mockResolvedValueOnce({
         id: '550e8400-e29b-41d4-a716-446655440000',
         userId: 'other-user-id',
@@ -227,7 +224,7 @@ describe('Chat API Handler (/api/chat)', () => {
     it('injects tools with strict projectId and user context during chat stream', async () => {
       const testUser = { id: 'user-uuid-123', email: 'test@example.com' };
       const projectId = '770e8400-e29b-41d4-a716-446655440000';
-      mockGetUser.mockResolvedValueOnce({ data: { user: testUser }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(testUser);
       mockGetChatById.mockResolvedValueOnce(null);
       mockGetProjectById.mockResolvedValueOnce({
         id: projectId,
@@ -284,7 +281,7 @@ describe('Chat API Handler (/api/chat)', () => {
 
   describe('DELETE /api/chat', () => {
     it('returns 401 Unauthorized when unauthenticated', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+      mockRequireAuthUser.mockRejectedValueOnce(new ChatbotError('unauthorized:chat'));
 
       const request = new Request(
         'http://localhost:3000/api/chat?id=550e8400-e29b-41d4-a716-446655440000',
@@ -299,7 +296,7 @@ describe('Chat API Handler (/api/chat)', () => {
 
     it('deletes chat when authenticated user owns it', async () => {
       const testUser = { id: 'user-uuid-123' };
-      mockGetUser.mockResolvedValueOnce({ data: { user: testUser }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(testUser);
       mockGetChatById.mockResolvedValueOnce({
         id: '550e8400-e29b-41d4-a716-446655440000',
         userId: testUser.id,

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -10,6 +10,7 @@ import {
 import { systemPrompt, titlePrompt } from '@/lib/ai/prompts';
 import { getLanguageModel, getTitleModel, type ProviderName } from '@/lib/ai/providers';
 import { createTools } from '@/lib/ai/tools';
+import { requireAuthUser } from '@/lib/auth/session';
 import {
   deleteChatById,
   getChatById,
@@ -20,7 +21,6 @@ import {
 } from '@/lib/db/queries/chat';
 import { getProjectById } from '@/lib/db/queries/project';
 import { ChatbotError } from '@/lib/errors';
-import { createClient } from '@/lib/supabase/server';
 import type { ChatMessage } from '@/lib/types';
 import { convertToUIMessages, generateUUID, getTextFromMessage } from '@/lib/utils';
 import { type PostRequestBody, postRequestBodySchema } from './schema';
@@ -121,14 +121,7 @@ export async function POST(request: Request) {
     const { id, message, messages, model, selectedChatModel, provider, apiKey, projectId } =
       requestBody;
 
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return new ChatbotError('unauthorized:chat').toResponse();
-    }
+    const user = await requireAuthUser();
 
     const modelId = model ?? selectedChatModel;
     const userMessage =
@@ -216,14 +209,7 @@ export async function DELETE(request: Request) {
       return new ChatbotError('bad_request:api').toResponse();
     }
 
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return new ChatbotError('unauthorized:chat').toResponse();
-    }
+    const user = await requireAuthUser();
 
     const chat = await getChatById({ id, userId: user.id });
 

--- a/app/api/history/route.test.ts
+++ b/app/api/history/route.test.ts
@@ -1,14 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatbotError } from '@/lib/errors';
 import { GET } from './route';
 
 // Mock dependencies
-const mockGetUser = vi.fn();
-vi.mock('@/lib/supabase/server', () => ({
-  createClient: vi.fn().mockImplementation(async () => ({
-    auth: {
-      getUser: mockGetUser,
-    },
-  })),
+const mockRequireAuthUser = vi.fn();
+vi.mock('@/lib/auth/session', () => ({
+  requireAuthUser: (...args: unknown[]) => mockRequireAuthUser(...args),
 }));
 
 const mockGetChatsByUserId = vi.fn();
@@ -22,7 +19,7 @@ describe('History API Handler (/api/history)', () => {
   });
 
   it('returns 401 Unauthorized when session is unauthenticated', async () => {
-    mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+    mockRequireAuthUser.mockRejectedValueOnce(new ChatbotError('unauthorized:chat'));
 
     const request = new Request('http://localhost:3000/api/history');
     const response = await GET(request);
@@ -34,7 +31,7 @@ describe('History API Handler (/api/history)', () => {
 
   it('returns user chat history when authenticated', async () => {
     const testUser = { id: 'user-uuid-123', email: 'test@example.com' };
-    mockGetUser.mockResolvedValueOnce({ data: { user: testUser }, error: null });
+    mockRequireAuthUser.mockResolvedValueOnce(testUser);
     const mockChats = [
       { id: 'chat-1', userId: testUser.id, title: 'Chat 1', createdAt: new Date() },
       { id: 'chat-2', userId: testUser.id, title: 'Chat 2', createdAt: new Date() },
@@ -58,7 +55,7 @@ describe('History API Handler (/api/history)', () => {
 
   it('filters by projectId when query parameter is provided', async () => {
     const testUser = { id: 'user-uuid-123', email: 'test@example.com' };
-    mockGetUser.mockResolvedValueOnce({ data: { user: testUser }, error: null });
+    mockRequireAuthUser.mockResolvedValueOnce(testUser);
     const mockChats = [
       {
         id: 'chat-1',

--- a/app/api/history/route.ts
+++ b/app/api/history/route.ts
@@ -1,20 +1,13 @@
+import { requireAuthUser } from '@/lib/auth/session';
 import { getChatsByUserId } from '@/lib/db/queries/chat';
 import { ChatbotError } from '@/lib/errors';
-import { createClient } from '@/lib/supabase/server';
 
 export const maxDuration = 60;
 
 // biome-ignore lint/style/useNamingConvention: Next.js HTTP method export
 export async function GET(request: Request) {
   try {
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return new ChatbotError('unauthorized:chat').toResponse();
-    }
+    const user = await requireAuthUser();
 
     const { searchParams } = new URL(request.url);
     const projectId = searchParams.get('projectId') || searchParams.get('project_id') || undefined;

--- a/app/api/projects/[id]/materials/[materialId]/route.test.ts
+++ b/app/api/projects/[id]/materials/[materialId]/route.test.ts
@@ -2,13 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ChatbotError } from '@/lib/errors';
 import { DELETE, GET } from './route';
 
-const mockGetUser = vi.fn();
-vi.mock('@/lib/supabase/server', () => ({
-  createClient: vi.fn().mockImplementation(async () => ({
-    auth: {
-      getUser: mockGetUser,
-    },
-  })),
+const mockRequireAuthUser = vi.fn();
+vi.mock('@/lib/auth/session', () => ({
+  requireAuthUser: (...args: unknown[]) => mockRequireAuthUser(...args),
 }));
 
 const mockGetProjectById = vi.fn();
@@ -24,13 +20,15 @@ vi.mock('@/lib/materials', () => ({
 }));
 
 describe('Project Single Material API Route (/api/projects/[id]/materials/[materialId])', () => {
+  const defaultUser = { id: 'user-1', email: 'test@example.com' };
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   describe('GET /api/projects/[id]/materials/[materialId]', () => {
     it('returns 401 when unauthenticated', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+      mockRequireAuthUser.mockRejectedValueOnce(new ChatbotError('unauthorized:chat'));
 
       const request = new Request('http://localhost:3000/api/projects/proj-1/materials/mat-1');
       const response = await GET(request, {
@@ -43,7 +41,7 @@ describe('Project Single Material API Route (/api/projects/[id]/materials/[mater
     });
 
     it('returns 404 when project does not exist for user', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce(null);
 
       const request = new Request('http://localhost:3000/api/projects/proj-1/materials/mat-1');
@@ -56,7 +54,7 @@ describe('Project Single Material API Route (/api/projects/[id]/materials/[mater
     });
 
     it('delegates to inspectMaterialContent and returns 200 with material, chunks, and content', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', userId: 'user-1' });
 
       const mockInspectionResult = {
@@ -122,7 +120,7 @@ describe('Project Single Material API Route (/api/projects/[id]/materials/[mater
     });
 
     it('maps not_found domain ChatbotError from inspectMaterialContent to 404 response', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', userId: 'user-1' });
       mockInspectMaterialContent.mockRejectedValueOnce(
         new ChatbotError('not_found:document', 'Material not found.'),
@@ -140,7 +138,7 @@ describe('Project Single Material API Route (/api/projects/[id]/materials/[mater
     });
 
     it('maps forbidden domain ChatbotError from inspectMaterialContent to 403 response', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', userId: 'user-1' });
       mockInspectMaterialContent.mockRejectedValueOnce(
         new ChatbotError('forbidden:document', 'This document belongs to another user.'),
@@ -158,7 +156,7 @@ describe('Project Single Material API Route (/api/projects/[id]/materials/[mater
     });
 
     it('maps bad_request domain ChatbotError from inspectMaterialContent to 400 response', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', userId: 'user-1' });
       mockInspectMaterialContent.mockRejectedValueOnce(
         new ChatbotError('bad_request:document', 'Invalid inspection request parameters.'),
@@ -176,7 +174,7 @@ describe('Project Single Material API Route (/api/projects/[id]/materials/[mater
     });
 
     it('returns 400 bad_request:api when an unexpected error occurs during inspection', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', userId: 'user-1' });
       mockInspectMaterialContent.mockRejectedValueOnce(new Error('Unexpected DB timeout'));
 
@@ -193,7 +191,7 @@ describe('Project Single Material API Route (/api/projects/[id]/materials/[mater
 
   describe('DELETE /api/projects/[id]/materials/[materialId]', () => {
     it('returns 401 when unauthenticated', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+      mockRequireAuthUser.mockRejectedValueOnce(new ChatbotError('unauthorized:chat'));
 
       const request = new Request('http://localhost:3000/api/projects/proj-1/materials/mat-1', {
         method: 'DELETE',
@@ -208,7 +206,7 @@ describe('Project Single Material API Route (/api/projects/[id]/materials/[mater
     });
 
     it('returns 404 when project does not exist for user', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce(null);
 
       const request = new Request('http://localhost:3000/api/projects/proj-1/materials/mat-1', {
@@ -225,7 +223,7 @@ describe('Project Single Material API Route (/api/projects/[id]/materials/[mater
     });
 
     it('delegates to deleteMaterial domain function and returns 200 with success and materialId', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', userId: 'user-1' });
 
       mockDeleteMaterial.mockResolvedValueOnce({
@@ -259,7 +257,7 @@ describe('Project Single Material API Route (/api/projects/[id]/materials/[mater
     });
 
     it('maps not_found domain ChatbotError from deleteMaterial to 404 response', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', userId: 'user-1' });
       mockDeleteMaterial.mockRejectedValueOnce(
         new ChatbotError('not_found:document', 'Material not found.'),
@@ -279,7 +277,7 @@ describe('Project Single Material API Route (/api/projects/[id]/materials/[mater
     });
 
     it('maps forbidden domain ChatbotError from deleteMaterial to 403 response', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', userId: 'user-1' });
       mockDeleteMaterial.mockRejectedValueOnce(
         new ChatbotError('forbidden:document', 'This document belongs to another user.'),
@@ -299,7 +297,7 @@ describe('Project Single Material API Route (/api/projects/[id]/materials/[mater
     });
 
     it('maps bad_request domain ChatbotError from deleteMaterial to 400 response', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', userId: 'user-1' });
       mockDeleteMaterial.mockRejectedValueOnce(
         new ChatbotError('bad_request:document', 'A valid material ID is required.'),
@@ -319,7 +317,7 @@ describe('Project Single Material API Route (/api/projects/[id]/materials/[mater
     });
 
     it('returns 400 bad_request:api when an unexpected error occurs during deletion', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', userId: 'user-1' });
       mockDeleteMaterial.mockRejectedValueOnce(new Error('Unexpected database failure'));
 

--- a/app/api/projects/[id]/materials/[materialId]/route.ts
+++ b/app/api/projects/[id]/materials/[materialId]/route.ts
@@ -1,7 +1,7 @@
+import { requireAuthUser } from '@/lib/auth/session';
 import { getProjectById } from '@/lib/db/queries/project';
 import { ChatbotError } from '@/lib/errors';
 import { deleteMaterial, inspectMaterialContent } from '@/lib/materials';
-import { createClient } from '@/lib/supabase/server';
 
 export const maxDuration = 60;
 
@@ -12,14 +12,7 @@ export async function GET(
 ) {
   try {
     const { id: projectId, materialId } = await params;
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return new ChatbotError('unauthorized:chat').toResponse();
-    }
+    const user = await requireAuthUser();
 
     const project = await getProjectById({ id: projectId, userId: user.id });
     if (!project) {
@@ -48,14 +41,7 @@ export async function DELETE(
 ) {
   try {
     const { id: projectId, materialId } = await params;
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return new ChatbotError('unauthorized:chat').toResponse();
-    }
+    const user = await requireAuthUser();
 
     const project = await getProjectById({ id: projectId, userId: user.id });
     if (!project) {

--- a/app/api/projects/[id]/materials/route.test.ts
+++ b/app/api/projects/[id]/materials/route.test.ts
@@ -2,13 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ChatbotError } from '@/lib/errors';
 import { GET, POST } from './route';
 
-const mockGetUser = vi.fn();
-vi.mock('@/lib/supabase/server', () => ({
-  createClient: vi.fn().mockImplementation(async () => ({
-    auth: {
-      getUser: mockGetUser,
-    },
-  })),
+const mockRequireAuthUser = vi.fn();
+vi.mock('@/lib/auth/session', () => ({
+  requireAuthUser: (...args: unknown[]) => mockRequireAuthUser(...args),
 }));
 
 const mockGetProjectById = vi.fn();
@@ -27,13 +23,15 @@ vi.mock('@/lib/materials', () => ({
 }));
 
 describe('Project Materials API Route (/api/projects/[id]/materials)', () => {
+  const defaultUser = { id: 'user-1', email: 'test@example.com' };
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   describe('GET /api/projects/[id]/materials', () => {
     it('returns 401 when unauthenticated', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+      mockRequireAuthUser.mockRejectedValueOnce(new ChatbotError('unauthorized:chat'));
 
       const request = new Request('http://localhost:3000/api/projects/proj-1/materials');
       const response = await GET(request, { params: Promise.resolve({ id: 'proj-1' }) });
@@ -44,7 +42,7 @@ describe('Project Materials API Route (/api/projects/[id]/materials)', () => {
     });
 
     it('returns 404 when project does not exist for user', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce(null);
 
       const request = new Request('http://localhost:3000/api/projects/proj-1/materials');
@@ -55,7 +53,7 @@ describe('Project Materials API Route (/api/projects/[id]/materials)', () => {
     });
 
     it('returns 200 with list of materials for project', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce({
         id: 'proj-1',
         name: 'Calculus',
@@ -79,7 +77,7 @@ describe('Project Materials API Route (/api/projects/[id]/materials)', () => {
     });
 
     it('returns 400 when an unexpected error occurs during material query', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce({
         id: 'proj-1',
         name: 'Calculus',
@@ -98,7 +96,7 @@ describe('Project Materials API Route (/api/projects/[id]/materials)', () => {
 
   describe('POST /api/projects/[id]/materials', () => {
     it('returns 401 when unauthenticated', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+      mockRequireAuthUser.mockRejectedValueOnce(new ChatbotError('unauthorized:chat'));
 
       const formData = new FormData();
       formData.append('file', new File(['hello'], 'notes.md', { type: 'text/markdown' }));
@@ -115,7 +113,7 @@ describe('Project Materials API Route (/api/projects/[id]/materials)', () => {
     });
 
     it('returns 404 when project does not exist or user is not owner', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce(null);
 
       const formData = new FormData();
@@ -132,7 +130,7 @@ describe('Project Materials API Route (/api/projects/[id]/materials)', () => {
     });
 
     it('returns 400 when no file is uploaded', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce({
         id: 'proj-1',
         name: 'Calculus',
@@ -154,7 +152,7 @@ describe('Project Materials API Route (/api/projects/[id]/materials)', () => {
     });
 
     it('returns 400 when file payload is a string instead of File', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce({
         id: 'proj-1',
         name: 'Calculus',
@@ -176,7 +174,7 @@ describe('Project Materials API Route (/api/projects/[id]/materials)', () => {
     });
 
     it('delegates to intakeMaterial with custom title and returns 201 on success', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce({
         id: 'proj-1',
         name: 'Calculus',
@@ -220,7 +218,7 @@ describe('Project Materials API Route (/api/projects/[id]/materials)', () => {
     });
 
     it('delegates to intakeMaterial without title (undefined) and returns 201 on success', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce({
         id: 'proj-1',
         name: 'Calculus',
@@ -263,7 +261,7 @@ describe('Project Materials API Route (/api/projects/[id]/materials)', () => {
     });
 
     it('maps domain ChatbotError from intakeMaterial to standard HTTP response', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce({
         id: 'proj-1',
         name: 'Calculus',
@@ -296,7 +294,7 @@ describe('Project Materials API Route (/api/projects/[id]/materials)', () => {
     });
 
     it('returns 400 when an unexpected error occurs during upload intake', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: 'user-1' } }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce({
         id: 'proj-1',
         name: 'Calculus',

--- a/app/api/projects/[id]/materials/route.ts
+++ b/app/api/projects/[id]/materials/route.ts
@@ -1,8 +1,8 @@
+import { requireAuthUser } from '@/lib/auth/session';
 import { getMaterialsByProjectId } from '@/lib/db/queries/material';
 import { getProjectById } from '@/lib/db/queries/project';
 import { ChatbotError } from '@/lib/errors';
 import { intakeMaterial } from '@/lib/materials';
-import { createClient } from '@/lib/supabase/server';
 
 export const maxDuration = 60;
 
@@ -10,14 +10,7 @@ export const maxDuration = 60;
 export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id: projectId } = await params;
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return new ChatbotError('unauthorized:chat').toResponse();
-    }
+    const user = await requireAuthUser();
 
     const project = await getProjectById({ id: projectId, userId: user.id });
     if (!project) {
@@ -38,14 +31,7 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id: projectId } = await params;
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return new ChatbotError('unauthorized:chat').toResponse();
-    }
+    const user = await requireAuthUser();
 
     const project = await getProjectById({ id: projectId, userId: user.id });
     if (!project) {

--- a/app/api/projects/[id]/route.test.ts
+++ b/app/api/projects/[id]/route.test.ts
@@ -1,14 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ChatbotError } from '@/lib/errors';
-import { DELETE, PATCH } from './route';
+import { DELETE, GET, PATCH } from './route';
 
-const mockGetUser = vi.fn();
-vi.mock('@/lib/supabase/server', () => ({
-  createClient: vi.fn().mockImplementation(async () => ({
-    auth: {
-      getUser: mockGetUser,
-    },
-  })),
+const mockRequireAuthUser = vi.fn();
+vi.mock('@/lib/auth/session', () => ({
+  requireAuthUser: (...args: unknown[]) => mockRequireAuthUser(...args),
 }));
 
 const mockUpdateProjectName = vi.fn();
@@ -27,16 +23,55 @@ vi.mock('@/lib/materials', () => ({
 }));
 
 describe('Project Item API Route (/api/projects/[id])', () => {
-  const defaultUser = { id: 'user-1' };
+  const defaultUser = { id: 'user-1', email: 'test@example.com' };
   const defaultProject = { id: 'p1', userId: 'user-1', name: 'Math' };
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
+  describe('GET /api/projects/[id]', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockRequireAuthUser.mockRejectedValueOnce(new ChatbotError('unauthorized:chat'));
+
+      const request = new Request('http://localhost:3000/api/projects/p1');
+      const response = await GET(request, { params: Promise.resolve({ id: 'p1' }) });
+
+      expect(response.status).toBe(401);
+      const json = await response.json();
+      expect(json.code).toBe('unauthorized:chat');
+    });
+
+    it('returns 404 when project does not exist for user', async () => {
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
+      mockGetProjectById.mockResolvedValueOnce(null);
+
+      const request = new Request('http://localhost:3000/api/projects/p1');
+      const response = await GET(request, { params: Promise.resolve({ id: 'p1' }) });
+
+      expect(response.status).toBe(404);
+      const json = await response.json();
+      expect(json.code).toBe('not_found:chat');
+      expect(mockGetProjectById).toHaveBeenCalledWith({ id: 'p1', userId: 'user-1' });
+    });
+
+    it('returns project when authenticated and project exists', async () => {
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
+      mockGetProjectById.mockResolvedValueOnce(defaultProject);
+
+      const request = new Request('http://localhost:3000/api/projects/p1');
+      const response = await GET(request, { params: Promise.resolve({ id: 'p1' }) });
+
+      expect(response.status).toBe(200);
+      const json = await response.json();
+      expect(json.project).toEqual(defaultProject);
+      expect(mockGetProjectById).toHaveBeenCalledWith({ id: 'p1', userId: 'user-1' });
+    });
+  });
+
   describe('PATCH /api/projects/[id]', () => {
     it('returns 401 when unauthenticated', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+      mockRequireAuthUser.mockRejectedValueOnce(new ChatbotError('unauthorized:chat'));
 
       const request = new Request('http://localhost:3000/api/projects/p1', {
         method: 'PATCH',
@@ -46,10 +81,12 @@ describe('Project Item API Route (/api/projects/[id])', () => {
       const response = await PATCH(request, { params: Promise.resolve({ id: 'p1' }) });
 
       expect(response.status).toBe(401);
+      const json = await response.json();
+      expect(json.code).toBe('unauthorized:chat');
     });
 
     it('returns 400 when name is invalid', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: defaultUser }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
 
       const request = new Request('http://localhost:3000/api/projects/p1', {
         method: 'PATCH',
@@ -62,7 +99,7 @@ describe('Project Item API Route (/api/projects/[id])', () => {
     });
 
     it('updates project and returns 200', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: defaultUser }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       const updated = { id: 'p1', name: 'Updated Name', userId: defaultUser.id };
       mockUpdateProjectName.mockResolvedValueOnce(updated);
 
@@ -86,16 +123,18 @@ describe('Project Item API Route (/api/projects/[id])', () => {
 
   describe('DELETE /api/projects/[id]', () => {
     it('returns 401 when unauthenticated', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+      mockRequireAuthUser.mockRejectedValueOnce(new ChatbotError('unauthorized:chat'));
 
       const request = new Request('http://localhost:3000/api/projects/p1', { method: 'DELETE' });
       const response = await DELETE(request, { params: Promise.resolve({ id: 'p1' }) });
 
       expect(response.status).toBe(401);
+      const json = await response.json();
+      expect(json.code).toBe('unauthorized:chat');
     });
 
     it('returns 404 when project does not exist or does not belong to user', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: defaultUser }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce(null);
 
       const request = new Request('http://localhost:3000/api/projects/p1', { method: 'DELETE' });
@@ -111,7 +150,7 @@ describe('Project Item API Route (/api/projects/[id])', () => {
     });
 
     it('purges storage blobs and deletes project database record in order, returning 200', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: defaultUser }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce(defaultProject);
 
       const callOrder: string[] = [];
@@ -149,7 +188,7 @@ describe('Project Item API Route (/api/projects/[id])', () => {
     });
 
     it('maps domain ChatbotError from storage purge to error response', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: defaultUser }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce(defaultProject);
       mockPurgeProjectMaterialsStorage.mockRejectedValueOnce(
         new ChatbotError('bad_request:document', 'A valid project ID is required.'),
@@ -166,7 +205,7 @@ describe('Project Item API Route (/api/projects/[id])', () => {
     });
 
     it('returns 400 bad_request:api when an unexpected error occurs during deletion', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: defaultUser }, error: null });
+      mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
       mockGetProjectById.mockResolvedValueOnce(defaultProject);
       mockPurgeProjectMaterialsStorage.mockRejectedValueOnce(new Error('Unexpected network crash'));
 

--- a/app/api/projects/[id]/route.ts
+++ b/app/api/projects/[id]/route.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
+import { requireAuthUser } from '@/lib/auth/session';
 import { deleteProjectById, getProjectById, updateProjectName } from '@/lib/db/queries/project';
 import { ChatbotError } from '@/lib/errors';
 import { purgeProjectMaterialsStorage } from '@/lib/materials';
-import { createClient } from '@/lib/supabase/server';
 
 export const maxDuration = 60;
 
@@ -11,17 +11,34 @@ const updateProjectSchema = z.object({
 });
 
 // biome-ignore lint/style/useNamingConvention: Next.js HTTP method export
+export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const user = await requireAuthUser();
+
+    const project = await getProjectById({
+      id,
+      userId: user.id,
+    });
+
+    if (!project) {
+      return new ChatbotError('not_found:chat', 'Project not found').toResponse();
+    }
+
+    return Response.json({ project }, { status: 200 });
+  } catch (error) {
+    if (error instanceof ChatbotError) {
+      return error.toResponse();
+    }
+    return new ChatbotError('bad_request:api').toResponse();
+  }
+}
+
+// biome-ignore lint/style/useNamingConvention: Next.js HTTP method export
 export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return new ChatbotError('unauthorized:chat').toResponse();
-    }
+    const user = await requireAuthUser();
 
     const json = await request.json();
     const parsed = updateProjectSchema.safeParse(json);
@@ -49,14 +66,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 export async function DELETE(_request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return new ChatbotError('unauthorized:chat').toResponse();
-    }
+    const user = await requireAuthUser();
 
     const project = await getProjectById({
       id,

--- a/app/api/projects/route.test.ts
+++ b/app/api/projects/route.test.ts
@@ -1,13 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatbotError } from '@/lib/errors';
 import { GET, POST } from './route';
 
-const mockGetUser = vi.fn();
-vi.mock('@/lib/supabase/server', () => ({
-  createClient: vi.fn().mockImplementation(async () => ({
-    auth: {
-      getUser: mockGetUser,
-    },
-  })),
+const mockRequireAuthUser = vi.fn();
+vi.mock('@/lib/auth/session', () => ({
+  requireAuthUser: (...args: unknown[]) => mockRequireAuthUser(...args),
 }));
 
 const mockGetProjectsWithChatCount = vi.fn();
@@ -25,17 +22,19 @@ describe('Projects API Route (/api/projects)', () => {
 
   describe('GET /api/projects', () => {
     it('returns 401 when unauthenticated', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+      mockRequireAuthUser.mockRejectedValueOnce(new ChatbotError('unauthorized:chat'));
 
       const request = new Request('http://localhost:3000/api/projects');
       const response = await GET(request);
 
       expect(response.status).toBe(401);
+      const json = await response.json();
+      expect(json.code).toBe('unauthorized:chat');
     });
 
     it('returns projects list when authenticated', async () => {
-      const testUser = { id: 'user-1' };
-      mockGetUser.mockResolvedValueOnce({ data: { user: testUser }, error: null });
+      const testUser = { id: 'user-1', email: 'test@example.com' };
+      mockRequireAuthUser.mockResolvedValueOnce(testUser);
       const mockProjects = [{ id: 'p1', name: 'Math', userId: 'user-1', chatCount: 2 }];
       mockGetProjectsWithChatCount.mockResolvedValueOnce(mockProjects);
 
@@ -51,7 +50,7 @@ describe('Projects API Route (/api/projects)', () => {
 
   describe('POST /api/projects', () => {
     it('returns 401 when unauthenticated', async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+      mockRequireAuthUser.mockRejectedValueOnce(new ChatbotError('unauthorized:chat'));
 
       const request = new Request('http://localhost:3000/api/projects', {
         method: 'POST',
@@ -61,11 +60,13 @@ describe('Projects API Route (/api/projects)', () => {
       const response = await POST(request);
 
       expect(response.status).toBe(401);
+      const json = await response.json();
+      expect(json.code).toBe('unauthorized:chat');
     });
 
     it('returns 400 when project name is empty or invalid', async () => {
-      const testUser = { id: 'user-1' };
-      mockGetUser.mockResolvedValueOnce({ data: { user: testUser }, error: null });
+      const testUser = { id: 'user-1', email: 'test@example.com' };
+      mockRequireAuthUser.mockResolvedValueOnce(testUser);
 
       const request = new Request('http://localhost:3000/api/projects', {
         method: 'POST',
@@ -78,8 +79,8 @@ describe('Projects API Route (/api/projects)', () => {
     });
 
     it('creates project and returns 201 when valid', async () => {
-      const testUser = { id: 'user-1' };
-      mockGetUser.mockResolvedValueOnce({ data: { user: testUser }, error: null });
+      const testUser = { id: 'user-1', email: 'test@example.com' };
+      mockRequireAuthUser.mockResolvedValueOnce(testUser);
       const mockCreated = { id: 'p1', name: 'Linear Algebra', userId: 'user-1' };
       mockCreateProject.mockResolvedValueOnce(mockCreated);
 

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
+import { requireAuthUser } from '@/lib/auth/session';
 import { createProject, getProjectsWithChatCount } from '@/lib/db/queries/project';
 import { ChatbotError } from '@/lib/errors';
-import { createClient } from '@/lib/supabase/server';
 
 export const maxDuration = 60;
 
@@ -12,14 +12,7 @@ const createProjectSchema = z.object({
 // biome-ignore lint/style/useNamingConvention: Next.js HTTP method export
 export async function GET(_request?: Request) {
   try {
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return new ChatbotError('unauthorized:chat').toResponse();
-    }
+    const user = await requireAuthUser();
 
     const projects = await getProjectsWithChatCount({ userId: user.id });
     return Response.json({ projects }, { status: 200 });
@@ -34,14 +27,7 @@ export async function GET(_request?: Request) {
 // biome-ignore lint/style/useNamingConvention: Next.js HTTP method export
 export async function POST(request: Request) {
   try {
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return new ChatbotError('unauthorized:chat').toResponse();
-    }
+    const user = await requireAuthUser();
 
     const json = await request.json();
     const parsed = createProjectSchema.safeParse(json);

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -1,12 +1,38 @@
 import { cookies } from 'next/headers';
+import { z } from 'zod';
+import { ChatbotError, type Surface } from '@/lib/errors';
 import { createClient } from '@/lib/supabase/server';
 
 export type AuthUser = {
-  id?: string;
+  id: string;
   email: string;
   fullName?: string;
   avatarUrl?: string;
 };
+
+export const CANONICAL_LOCAL_USER_ID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+
+export const CANONICAL_LOCAL_USER: AuthUser = {
+  id: CANONICAL_LOCAL_USER_ID,
+  email: 'local@learner.ai',
+  fullName: 'Local Learner',
+};
+
+const mockAuthCookieSchema = z.object({
+  id: z.string().optional(),
+  email: z.string().optional().default(''),
+  // biome-ignore lint/style/useNamingConvention: Supabase metadata property name
+  user_metadata: z
+    .object({
+      // biome-ignore lint/style/useNamingConvention: Supabase metadata property name
+      full_name: z.string().optional(),
+      // biome-ignore lint/style/useNamingConvention: Supabase metadata property name
+      avatar_url: z.string().optional(),
+    })
+    .optional(),
+  fullName: z.string().optional(),
+  avatarUrl: z.string().optional(),
+});
 
 async function getMockDevUser(): Promise<AuthUser | null> {
   if (process.env.PLAYWRIGHT_TEST !== 'true' && process.env.LOCAL_DEV_AUTH !== 'true') {
@@ -20,12 +46,19 @@ async function getMockDevUser(): Promise<AuthUser | null> {
   }
 
   try {
-    const parsed = JSON.parse(mockAuth.value);
+    const rawVal = mockAuth.value;
+    const decoded = rawVal.includes('%') ? decodeURIComponent(rawVal) : rawVal;
+    const parsed = mockAuthCookieSchema.safeParse(JSON.parse(decoded));
+    if (!parsed.success) {
+      return null;
+    }
+
+    const { id, email, user_metadata, fullName, avatarUrl } = parsed.data;
     return {
-      id: parsed.id ?? 'mock-user-id',
-      email: parsed.email ?? '',
-      fullName: (parsed.user_metadata?.full_name as string | undefined) ?? undefined,
-      avatarUrl: (parsed.user_metadata?.avatar_url as string | undefined) ?? undefined,
+      id: id ?? CANONICAL_LOCAL_USER_ID,
+      email,
+      fullName: user_metadata?.full_name ?? fullName,
+      avatarUrl: user_metadata?.avatar_url ?? avatarUrl,
     };
   } catch {
     return null;
@@ -33,6 +66,10 @@ async function getMockDevUser(): Promise<AuthUser | null> {
 }
 
 export async function getCurrentUser(): Promise<AuthUser | null> {
+  if (process.env.LOCAL_MODE === 'true') {
+    return CANONICAL_LOCAL_USER;
+  }
+
   try {
     const supabase = await createClient();
     const {
@@ -47,10 +84,19 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
         avatarUrl: (user.user_metadata?.avatar_url as string | undefined) ?? undefined,
       };
     }
-
-    return await getMockDevUser();
   } catch (error) {
-    console.error('Failed to fetch user session:', error);
-    return null;
+    if (process.env.PLAYWRIGHT_TEST !== 'true' && process.env.LOCAL_DEV_AUTH !== 'true') {
+      console.error('Failed to fetch user session from Supabase:', error);
+    }
   }
+
+  return await getMockDevUser();
+}
+
+export async function requireAuthUser(surface: Surface = 'chat'): Promise<AuthUser> {
+  const user = await getCurrentUser();
+  if (!user) {
+    throw new ChatbotError(`unauthorized:${surface}`);
+  }
+  return user;
 }

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,7 +1,8 @@
 import { createServerClient } from '@supabase/ssr';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { cookies } from 'next/headers';
 
-export async function createClient() {
+export async function createClient(): Promise<SupabaseClient> {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
@@ -11,7 +12,7 @@ export async function createClient() {
 
   const cookieStore = await cookies();
 
-  const supabase = createServerClient(url, anonKey, {
+  return createServerClient(url, anonKey, {
     cookies: {
       getAll() {
         return cookieStore.getAll();
@@ -28,41 +29,4 @@ export async function createClient() {
       },
     },
   });
-
-  if (process.env.PLAYWRIGHT_TEST === 'true' || process.env.LOCAL_DEV_AUTH === 'true') {
-    const mockAuth = cookieStore.get('sb-mock-auth');
-    if (mockAuth?.value) {
-      const origGetUser = supabase.auth.getUser.bind(supabase.auth);
-      supabase.auth.getUser = (async (jwt?: string) => {
-        const res = await origGetUser(jwt).catch(
-          () =>
-            ({ data: { user: null }, error: null }) as unknown as Awaited<
-              ReturnType<typeof origGetUser>
-            >,
-        );
-        if (res?.data?.user) return res;
-        try {
-          const rawVal = mockAuth.value;
-          const decoded = rawVal.includes('%') ? decodeURIComponent(rawVal) : rawVal;
-          const parsed = JSON.parse(decoded);
-          const mockUser = {
-            id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
-            email: parsed.email || 'test@example.com',
-            // biome-ignore lint/style/useNamingConvention: Supabase metadata key
-            user_metadata: parsed.user_metadata || { full_name: 'Test User' },
-            // biome-ignore lint/style/useNamingConvention: Supabase metadata key
-            app_metadata: {},
-            aud: 'authenticated',
-            // biome-ignore lint/style/useNamingConvention: Supabase metadata key
-            created_at: new Date().toISOString(),
-          };
-          return { data: { user: mockUser as unknown as typeof res.data.user }, error: null };
-        } catch {
-          return res;
-        }
-      }) as typeof origGetUser;
-    }
-  }
-
-  return supabase;
 }

--- a/lib/supabase/supabase.test.ts
+++ b/lib/supabase/supabase.test.ts
@@ -1,49 +1,184 @@
+import {
+  createBrowserClient as ssrCreateBrowserClient,
+  createServerClient as ssrCreateServerClient,
+} from '@supabase/ssr';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { cookies } from 'next/headers';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createClient as createBrowserClient } from './client';
 import { createClient as createServerClient } from './server';
 
+type CookieToSet = {
+  name: string;
+  value: string;
+  options?: Record<string, unknown>;
+};
+
+type CookieAdapter = {
+  getAll: () => Array<{ name: string; value: string }>;
+  setAll: (cookies: CookieToSet[]) => void;
+};
+
+type MockServerClient = SupabaseClient & {
+  _options?: {
+    cookies?: CookieAdapter;
+  };
+  _originalGetUser: ReturnType<typeof vi.fn>;
+};
+
 vi.mock('next/headers', () => ({
-  cookies: vi.fn().mockResolvedValue({
-    getAll: vi.fn().mockReturnValue([]),
-    set: vi.fn(),
-  }),
+  cookies: vi.fn(),
+}));
+
+vi.mock('@supabase/ssr', () => ({
+  createBrowserClient: vi.fn((url: string, anonKey: string) => ({
+    url,
+    anonKey,
+    auth: { getUser: vi.fn() },
+  })),
+  createServerClient: vi.fn(
+    (url: string, anonKey: string, options: { cookies?: CookieAdapter }) => {
+      const originalGetUser = vi.fn().mockResolvedValue({
+        data: { user: null },
+        error: new Error('Auth session missing'),
+      });
+      return {
+        url,
+        anonKey,
+        auth: { getUser: originalGetUser },
+        _options: options,
+        _originalGetUser: originalGetUser,
+      } as unknown as SupabaseClient;
+    },
+  ),
 }));
 
 describe('Supabase Client Factories', () => {
   const originalEnv = process.env;
+  const mockCookieGet = vi.fn();
+  const mockCookieGetAll = vi.fn();
+  const mockCookieSet = vi.fn();
 
   beforeEach(() => {
-    vi.resetModules();
+    vi.clearAllMocks();
     process.env = { ...originalEnv };
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key-123';
+
+    mockCookieGet.mockReset();
+    mockCookieGetAll.mockReset().mockReturnValue([]);
+    mockCookieSet.mockReset();
+
+    vi.mocked(cookies).mockResolvedValue({
+      get: mockCookieGet,
+      getAll: mockCookieGetAll,
+      set: mockCookieSet,
+    } as unknown as Awaited<ReturnType<typeof cookies>>);
   });
 
   afterEach(() => {
     process.env = originalEnv;
   });
 
-  it('throws error when env vars are missing in browser client', () => {
-    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
-    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-    expect(() => createBrowserClient()).toThrow('Missing Supabase environment variables');
+  describe('createBrowserClient', () => {
+    it('throws error when env vars are missing', () => {
+      delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+      delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+      expect(() => createBrowserClient()).toThrow('Missing Supabase environment variables');
+    });
+
+    it('instantiates browser client when env vars are present', () => {
+      const client = createBrowserClient();
+      expect(client).toBeDefined();
+      expect(ssrCreateBrowserClient).toHaveBeenCalledWith(
+        'https://example.supabase.co',
+        'anon-key-123',
+      );
+    });
   });
 
-  it('instantiates browser client when env vars are present', () => {
-    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key-123';
-    const client = createBrowserClient();
-    expect(client).toBeDefined();
-  });
+  describe('createServerClient', () => {
+    it('throws error when env vars are missing', async () => {
+      delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+      delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+      await expect(createServerClient()).rejects.toThrow('Missing Supabase environment variables');
+    });
 
-  it('throws error when env vars are missing in server client', async () => {
-    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
-    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-    await expect(createServerClient()).rejects.toThrow('Missing Supabase environment variables');
-  });
+    it('instantiates server client when env vars are present', async () => {
+      const client = await createServerClient();
+      expect(client).toBeDefined();
+      expect(ssrCreateServerClient).toHaveBeenCalledWith(
+        'https://example.supabase.co',
+        'anon-key-123',
+        expect.objectContaining({
+          cookies: expect.any(Object),
+        }),
+      );
+    });
 
-  it('instantiates server client when env vars are present', async () => {
-    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key-123';
-    const client = await createServerClient();
-    expect(client).toBeDefined();
+    it('passes pure cookie adapter getAll to cookieStore.getAll', async () => {
+      mockCookieGetAll.mockReturnValueOnce([{ name: 'sb-token', value: 'xyz' }]);
+
+      const client = (await createServerClient()) as unknown as MockServerClient;
+      const cookieAdapter = client._options?.cookies;
+      expect(cookieAdapter?.getAll).toBeDefined();
+
+      const result = cookieAdapter?.getAll();
+      expect(result).toEqual([{ name: 'sb-token', value: 'xyz' }]);
+      expect(mockCookieGetAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes pure cookie adapter setAll to cookieStore.set', async () => {
+      const client = (await createServerClient()) as unknown as MockServerClient;
+      const cookieAdapter = client._options?.cookies;
+      expect(cookieAdapter?.setAll).toBeDefined();
+
+      cookieAdapter?.setAll([
+        { name: 'cookie1', value: 'val1', options: { path: '/' } },
+        { name: 'cookie2', value: 'val2', options: { httpOnly: true } },
+      ]);
+
+      expect(mockCookieSet).toHaveBeenCalledTimes(2);
+      expect(mockCookieSet).toHaveBeenNthCalledWith(1, 'cookie1', 'val1', { path: '/' });
+      expect(mockCookieSet).toHaveBeenNthCalledWith(2, 'cookie2', 'val2', { httpOnly: true });
+    });
+
+    it('ignores errors thrown in setAll when executed from a Server Component context', async () => {
+      mockCookieSet.mockImplementation(() => {
+        throw new Error('Cookies can only be modified in a Server Action or Route Handler.');
+      });
+
+      const client = (await createServerClient()) as unknown as MockServerClient;
+      const cookieAdapter = client._options?.cookies;
+
+      expect(() => {
+        cookieAdapter?.setAll([{ name: 'c', value: 'v', options: {} }]);
+      }).not.toThrow();
+    });
+
+    it.each([
+      ['PLAYWRIGHT_TEST', 'e2e@example.com'],
+      ['LOCAL_DEV_AUTH', 'dev@example.com'],
+    ])(
+      'does not mutate or monkeypatch supabase.auth.getUser when %s is true and sb-mock-auth cookie is present',
+      async (envVar, email) => {
+        process.env[envVar] = 'true';
+
+        mockCookieGet.mockReturnValue({
+          name: 'sb-mock-auth',
+          value: JSON.stringify({ email }),
+        });
+
+        const client = (await createServerClient()) as unknown as MockServerClient;
+
+        // The getUser method must remain the unmutated original reference from @supabase/ssr
+        expect(client.auth.getUser).toBe(client._originalGetUser);
+
+        // Calling getUser should execute the standard supabase client method without monkeypatched interception
+        const res = await client.auth.getUser();
+        expect(res.data.user).toBeNull();
+        expect(res.error).toBeDefined();
+      },
+    );
   });
 });

--- a/tests/unit/auth-session.test.ts
+++ b/tests/unit/auth-session.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { getCurrentUser } from '@/lib/auth/session';
+import {
+  CANONICAL_LOCAL_USER,
+  CANONICAL_LOCAL_USER_ID,
+  getCurrentUser,
+  requireAuthUser,
+} from '@/lib/auth/session';
+import { ChatbotError } from '@/lib/errors';
 
 const mockGetUser = vi.fn();
 
@@ -18,75 +24,273 @@ vi.mock('next/headers', () => ({
   })),
 }));
 
-describe('getCurrentUser', () => {
+describe('auth session module', () => {
   const originalEnv = process.env;
 
   beforeEach(() => {
     vi.clearAllMocks();
     process.env = { ...originalEnv };
+    delete process.env.LOCAL_MODE;
+    delete process.env.PLAYWRIGHT_TEST;
+    delete process.env.LOCAL_DEV_AUTH;
   });
 
-  it('returns authenticated user from Supabase when available', async () => {
-    mockGetUser.mockResolvedValueOnce({
-      data: {
-        user: {
+  describe('CANONICAL_LOCAL_USER constants', () => {
+    it('defines canonical local user ID as a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', () => {
+      expect(CANONICAL_LOCAL_USER_ID).toBe('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
+      expect(CANONICAL_LOCAL_USER.id).toBe('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
+      expect(CANONICAL_LOCAL_USER.email).toBeDefined();
+    });
+  });
+
+  describe('getCurrentUser', () => {
+    describe('Cloud Supabase Mode', () => {
+      it('returns authenticated user from Supabase when session exists', async () => {
+        mockGetUser.mockResolvedValueOnce({
+          data: {
+            user: {
+              id: 'user-123',
+              email: 'user@example.com',
+              // biome-ignore lint/style/useNamingConvention: Supabase metadata property names
+              user_metadata: {
+                // biome-ignore lint/style/useNamingConvention: Supabase metadata property names
+                full_name: 'Test User',
+                // biome-ignore lint/style/useNamingConvention: Supabase metadata property names
+                avatar_url: 'https://example.com/avatar.png',
+              },
+            },
+          },
+          error: null,
+        });
+
+        const user = await getCurrentUser();
+        expect(user).toEqual({
           id: 'user-123',
           email: 'user@example.com',
+          fullName: 'Test User',
+          avatarUrl: 'https://example.com/avatar.png',
+        });
+      });
+
+      it('returns null when Supabase returns no user', async () => {
+        mockGetUser.mockResolvedValueOnce({
+          data: { user: null },
+          error: null,
+        });
+
+        const user = await getCurrentUser();
+        expect(user).toBeNull();
+      });
+
+      it('returns null gracefully when Supabase client throws an error in cloud mode', async () => {
+        mockGetUser.mockRejectedValueOnce(new Error('Network error'));
+
+        const user = await getCurrentUser();
+        expect(user).toBeNull();
+      });
+    });
+
+    describe('Local Privacy Mode (LOCAL_MODE=true)', () => {
+      it('resolves canonical local user even without session cookie or Supabase call', async () => {
+        process.env.LOCAL_MODE = 'true';
+
+        const user = await getCurrentUser();
+        expect(user).toEqual({
+          id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+          email: 'local@learner.ai',
+          fullName: 'Local Learner',
+        });
+        expect(mockGetUser).not.toHaveBeenCalled();
+        expect(mockCookieGet).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('Dev / Test Mode', () => {
+      it('parses sb-mock-auth cookie and defaults to canonical UUID when id is omitted (PLAYWRIGHT_TEST=true)', async () => {
+        process.env.PLAYWRIGHT_TEST = 'true';
+        mockGetUser.mockResolvedValueOnce({
+          data: { user: null },
+          error: null,
+        });
+
+        mockCookieGet.mockReturnValueOnce({
+          value: JSON.stringify({
+            email: 'e2e@example.com',
+            // biome-ignore lint/style/useNamingConvention: Supabase metadata property names
+            user_metadata: {
+              // biome-ignore lint/style/useNamingConvention: Supabase metadata property names
+              full_name: 'E2E User',
+            },
+          }),
+        });
+
+        const user = await getCurrentUser();
+        expect(user).toEqual({
+          id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+          email: 'e2e@example.com',
+          fullName: 'E2E User',
+          avatarUrl: undefined,
+        });
+      });
+
+      it('preserves explicit id from sb-mock-auth cookie when provided', async () => {
+        process.env.LOCAL_DEV_AUTH = 'true';
+        mockGetUser.mockResolvedValueOnce({
+          data: { user: null },
+          error: null,
+        });
+
+        mockCookieGet.mockReturnValueOnce({
+          value: JSON.stringify({
+            id: 'custom-dev-id',
+            email: 'dev@example.com',
+            fullName: 'Dev User',
+            avatarUrl: 'https://example.com/dev.png',
+          }),
+        });
+
+        const user = await getCurrentUser();
+        expect(user).toEqual({
+          id: 'custom-dev-id',
+          email: 'dev@example.com',
+          fullName: 'Dev User',
+          avatarUrl: 'https://example.com/dev.png',
+        });
+      });
+
+      it('handles URL-encoded sb-mock-auth cookie value', async () => {
+        process.env.PLAYWRIGHT_TEST = 'true';
+        mockGetUser.mockResolvedValueOnce({
+          data: { user: null },
+          error: null,
+        });
+
+        const rawJson = JSON.stringify({
+          email: 'encoded@example.com',
           // biome-ignore lint/style/useNamingConvention: Supabase metadata property names
-          user_metadata: {
+          user_metadata: { full_name: 'Encoded User' },
+        });
+
+        mockCookieGet.mockReturnValueOnce({
+          value: encodeURIComponent(rawJson),
+        });
+
+        const user = await getCurrentUser();
+        expect(user).toEqual({
+          id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+          email: 'encoded@example.com',
+          fullName: 'Encoded User',
+          avatarUrl: undefined,
+        });
+      });
+
+      it('returns null when sb-mock-auth cookie contains invalid JSON', async () => {
+        process.env.PLAYWRIGHT_TEST = 'true';
+        mockGetUser.mockResolvedValueOnce({
+          data: { user: null },
+          error: null,
+        });
+
+        mockCookieGet.mockReturnValueOnce({
+          value: 'invalid-json-string',
+        });
+
+        const user = await getCurrentUser();
+        expect(user).toBeNull();
+      });
+
+      it('returns null when sb-mock-auth cookie is missing in dev/test mode', async () => {
+        process.env.PLAYWRIGHT_TEST = 'true';
+        mockGetUser.mockResolvedValueOnce({
+          data: { user: null },
+          error: null,
+        });
+
+        mockCookieGet.mockReturnValueOnce(undefined);
+
+        const user = await getCurrentUser();
+        expect(user).toBeNull();
+      });
+    });
+  });
+
+  describe('requireAuthUser', () => {
+    it('returns verified AuthUser when session is valid', async () => {
+      mockGetUser.mockResolvedValueOnce({
+        data: {
+          user: {
+            id: 'valid-user-123',
+            email: 'valid@example.com',
             // biome-ignore lint/style/useNamingConvention: Supabase metadata property names
-            full_name: 'Test User',
-            // biome-ignore lint/style/useNamingConvention: Supabase metadata property names
-            avatar_url: 'https://example.com/avatar.png',
+            user_metadata: {
+              // biome-ignore lint/style/useNamingConvention: Supabase metadata property names
+              full_name: 'Valid User',
+            },
           },
         },
-      },
-      error: null,
+        error: null,
+      });
+
+      const user = await requireAuthUser();
+      expect(user).toEqual({
+        id: 'valid-user-123',
+        email: 'valid@example.com',
+        fullName: 'Valid User',
+        avatarUrl: undefined,
+      });
     });
 
-    const user = await getCurrentUser();
-    expect(user).toEqual({
-      id: 'user-123',
-      email: 'user@example.com',
-      fullName: 'Test User',
-      avatarUrl: 'https://example.com/avatar.png',
-    });
-  });
+    it('returns verified AuthUser in Local Privacy Mode', async () => {
+      process.env.LOCAL_MODE = 'true';
 
-  it('falls back to mock auth cookie when PLAYWRIGHT_TEST is true and no supabase user', async () => {
-    process.env.PLAYWRIGHT_TEST = 'true';
-    mockGetUser.mockResolvedValueOnce({
-      data: { user: null },
-      error: null,
+      const user = await requireAuthUser();
+      expect(user).toEqual({
+        id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+        email: 'local@learner.ai',
+        fullName: 'Local Learner',
+      });
     });
 
-    mockCookieGet.mockReturnValueOnce({
-      value: JSON.stringify({
-        email: 'e2e@example.com',
-        // biome-ignore lint/style/useNamingConvention: Supabase metadata property names
-        user_metadata: {
-          // biome-ignore lint/style/useNamingConvention: Supabase metadata property names
-          full_name: 'E2E User',
-        },
-      }),
+    it('throws ChatbotError with unauthorized:chat by default when user is null', async () => {
+      mockGetUser.mockResolvedValueOnce({
+        data: { user: null },
+        error: null,
+      });
+
+      await expect(requireAuthUser()).rejects.toThrow(ChatbotError);
+
+      try {
+        mockGetUser.mockResolvedValueOnce({
+          data: { user: null },
+          error: null,
+        });
+        await requireAuthUser();
+      } catch (err) {
+        expect(err).toBeInstanceOf(ChatbotError);
+        const chatbotErr = err as ChatbotError;
+        expect(chatbotErr.statusCode).toBe(401);
+        expect(chatbotErr.type).toBe('unauthorized');
+        expect(chatbotErr.surface).toBe('chat');
+        const response = chatbotErr.toResponse();
+        expect(response.status).toBe(401);
+      }
     });
 
-    const user = await getCurrentUser();
-    expect(user).toEqual({
-      id: 'mock-user-id',
-      email: 'e2e@example.com',
-      fullName: 'E2E User',
-      avatarUrl: undefined,
-    });
-  });
+    it('throws ChatbotError with custom surface when provided', async () => {
+      mockGetUser.mockResolvedValueOnce({
+        data: { user: null },
+        error: null,
+      });
 
-  it('returns null when no user session exists', async () => {
-    mockGetUser.mockResolvedValueOnce({
-      data: { user: null },
-      error: null,
+      try {
+        await requireAuthUser('api');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ChatbotError);
+        const chatbotErr = err as ChatbotError;
+        expect(chatbotErr.statusCode).toBe(401);
+        expect(chatbotErr.type).toBe('unauthorized');
+        expect(chatbotErr.surface).toBe('api');
+      }
     });
-
-    const user = await getCurrentUser();
-    expect(user).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Consolidated implementation for epic `epic-unify-auth-session`.
Closes #93
Closes #94
Closes #95
Closes #96
Closes #97

## Changes

- **Deep Authentication Session Module (`lib/auth/session.ts`)**:
  - Implemented `getCurrentUser()` for optional/safe session retrieval across Cloud Supabase, Local Privacy Mode (`LOCAL_MODE=true`), and Dev/Test cookie modes.
  - Implemented `requireAuthUser(surface?: Surface)` for strict session verification, throwing standardized `ChatbotError('unauthorized:chat')`.
  - Added canonical local/test UUID fallback (`a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11`) and Zod-validated mock cookie parsing.
- **Pure Supabase SSR Adapter (`lib/supabase/server.ts`)**:
  - Removed `auth.getUser` runtime monkeypatching and `sb-mock-auth` cookie inspection.
  - `createClient()` is now a pure `@supabase/ssr` server client factory.
- **Route Handler Migrations**:
  - Migrated `/api/chat` (POST, DELETE) and `/api/history` (GET) to `requireAuthUser()`.
  - Migrated `/api/projects` (GET, POST), `/api/projects/[id]` (GET, PATCH, DELETE), `/api/projects/[id]/materials` (GET, POST), and `/api/projects/[id]/materials/[materialId]` (GET, DELETE) to `requireAuthUser()`.

## Definition of Done

- [x] All acceptance criteria for #94 verified
- [x] All acceptance criteria for #95 verified
- [x] All acceptance criteria for #96 verified
- [x] All acceptance criteria for #97 verified
- [x] All acceptance criteria for parent spec #93 verified

## Verification

- [x] `pnpm check` passes (lint + typecheck + 36 test files / 323 tests green)
- [x] Subagent code reviews completed (Standards & Spec)