### PR TITLE
feat(graph): concept graph extraction, cycle-guarded queries & practice discovery

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -81,6 +81,26 @@ _Avoid_: Snippet, passage, fragment
 A structured graph of entities, relationships, and concepts extracted across ingested materials to support multi-hop reasoning.
 _Avoid_: Concept map, mindmap, ontology
 
+**Knowledge Component (KC)**:
+The atomic, learnable unit of knowledge (concept, principle, procedural method, or factual relation) extracted from materials, categorized by PACER classification and indexed by Bloom cognitive level.
+_Avoid_: Concept node, topic item, skill node, entity, node
+
+**Knowledge Dependency**:
+A directed pedagogical prerequisite or structural relationship connecting two Knowledge Components, enriched with reasoning justifying why one concept precedes or supports another.
+_Avoid_: Edge, relation, link, connection, dependency link
+
+**PACER Category**:
+The pedagogical classification system categorizing Knowledge Components into Procedural, Analogous, Conceptual, Evidence, or Reference types.
+_Avoid_: Concept type, node category, KC type
+
+**Bloom Level**:
+The cognitive complexity rating (1 to 6: Remember, Understand, Apply, Analyze, Evaluate, Create) indicating the mastery depth required for a Knowledge Component.
+_Avoid_: Difficulty score, complexity level, cognitive stage
+
+**Grounded Exercise**:
+A practice assessment problem (multiple-choice, calculation, conceptual query, or code task) synthesized during concept extraction and strictly linked to a Knowledge Component and source material page attribution.
+_Avoid_: Quiz item, test question, drill, homework problem
+
 **GraphRAG**:
 Retrieval-Augmented Generation that queries both vector similarity and knowledge graph relationships to ground model responses in materials.
 _Avoid_: RAG, vector search, semantic search

--- a/app/api/chat/route.test.ts
+++ b/app/api/chat/route.test.ts
@@ -33,6 +33,10 @@ const mockCreateTools = vi.fn().mockImplementation((_opts) => ({
     description: 'prerequisite chain',
     execute: vi.fn().mockResolvedValue({ summary: '[OK: 0 prerequisite ancestors]' }),
   },
+  getExercisesForKc: {
+    description: 'exercises for kc',
+    execute: vi.fn().mockResolvedValue({ summary: '[OK: 0 exercises found for Concept]' }),
+  },
 }));
 
 vi.mock('@/lib/ai/tools', () => ({
@@ -284,6 +288,60 @@ describe('Chat API Handler (/api/chat)', () => {
           apiKey: 'custom-byok-key',
         }),
       );
+    });
+
+    it('provides getExercisesForKc tool in chat stream for exercise discovery', async () => {
+      const testUser = { id: 'user-uuid-123', email: 'test@example.com' };
+      const projectId = '770e8400-e29b-41d4-a716-446655440000';
+      mockRequireAuthUser.mockResolvedValueOnce(testUser);
+      mockGetChatById.mockResolvedValueOnce(null);
+      mockGetProjectById.mockResolvedValueOnce({
+        id: projectId,
+        userId: testUser.id,
+        name: 'Calculus',
+      });
+      mockSaveChat.mockResolvedValueOnce({
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        userId: testUser.id,
+        projectId,
+        title: 'New chat',
+      });
+
+      const request = new Request('http://localhost:3000/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          id: '550e8400-e29b-41d4-a716-446655440000',
+          projectId,
+          message: {
+            id: '11111111-2222-4444-8888-999999999999',
+            role: 'user',
+            parts: [{ type: 'text', text: 'Give me practice exercises for derivatives' }],
+          },
+        }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      const reader = response.body?.getReader();
+      if (reader) {
+        let done = false;
+        while (!done) {
+          const res = await reader.read();
+          done = res.done;
+        }
+      }
+
+      expect(mockCreateTools).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: testUser.id,
+          projectId,
+        }),
+      );
+      const createdTools =
+        mockCreateTools.mock.results[mockCreateTools.mock.results.length - 1]?.value;
+      expect(createdTools).toHaveProperty('getExercisesForKc');
     });
   });
 

--- a/app/api/chat/route.test.ts
+++ b/app/api/chat/route.test.ts
@@ -25,6 +25,14 @@ const mockCreateTools = vi.fn().mockImplementation((_opts) => ({
     description: 'search materials',
     execute: vi.fn().mockResolvedValue({ results: [] }),
   },
+  getGraphNeighborhood: {
+    description: 'graph neighborhood',
+    execute: vi.fn().mockResolvedValue({ summary: '[OK: 0 prerequisites, 0 unlocked]' }),
+  },
+  getPrerequisiteChain: {
+    description: 'prerequisite chain',
+    execute: vi.fn().mockResolvedValue({ summary: '[OK: 0 prerequisite ancestors]' }),
+  },
 }));
 
 vi.mock('@/lib/ai/tools', () => ({

--- a/app/api/projects/[id]/graph/extract/route.test.ts
+++ b/app/api/projects/[id]/graph/extract/route.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatbotError } from '@/lib/errors';
+import { POST } from './route';
+
+const mockRequireAuthUser = vi.fn();
+vi.mock('@/lib/auth/session', () => ({
+  requireAuthUser: (...args: unknown[]) => mockRequireAuthUser(...args),
+}));
+
+const mockGetProjectById = vi.fn();
+vi.mock('@/lib/db/queries/project', () => ({
+  getProjectById: (...args: unknown[]) => mockGetProjectById(...args),
+}));
+
+const mockGetMaterialsByProjectId = vi.fn();
+const mockUpdateMaterialStatus = vi.fn();
+vi.mock('@/lib/db/queries/material', () => ({
+  getMaterialsByProjectId: (...args: unknown[]) => mockGetMaterialsByProjectId(...args),
+  updateMaterialStatus: (...args: unknown[]) => mockUpdateMaterialStatus(...args),
+}));
+
+const mockSendConceptGraphExtractJob = vi.fn();
+vi.mock('@/lib/queue/boss', () => ({
+  sendConceptGraphExtractJob: (...args: unknown[]) => mockSendConceptGraphExtractJob(...args),
+}));
+
+describe('POST /api/projects/[id]/graph/extract', () => {
+  const defaultUser = { id: 'user-1', email: 'test@example.com' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockRequireAuthUser.mockRejectedValueOnce(new ChatbotError('unauthorized:chat'));
+
+    const request = new Request('http://localhost:3000/api/projects/proj-1/graph/extract', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ materialIds: ['mat-1'] }),
+    });
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'proj-1' }) });
+
+    expect(response.status).toBe(401);
+    const json = await response.json();
+    expect(json.code).toBe('unauthorized:chat');
+  });
+
+  it('returns 404 when project does not exist for user', async () => {
+    mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
+    mockGetProjectById.mockResolvedValueOnce(null);
+
+    const request = new Request('http://localhost:3000/api/projects/proj-1/graph/extract', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ materialIds: ['mat-1'] }),
+    });
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'proj-1' }) });
+
+    expect(response.status).toBe(404);
+    expect(mockGetProjectById).toHaveBeenCalledWith({ id: 'proj-1', userId: 'user-1' });
+  });
+
+  it('returns 400 when specified material does not belong to project', async () => {
+    mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
+    mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', name: 'CS101', userId: 'user-1' });
+    mockGetMaterialsByProjectId.mockResolvedValueOnce([
+      { id: 'mat-other', projectId: 'proj-1', status: 'ready', metadata: {} },
+    ]);
+
+    const request = new Request('http://localhost:3000/api/projects/proj-1/graph/extract', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ materialIds: ['mat-not-in-project'] }),
+    });
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'proj-1' }) });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('enqueues graph extraction for single material and returns 202', async () => {
+    mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
+    mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', name: 'CS101', userId: 'user-1' });
+    mockGetMaterialsByProjectId.mockResolvedValueOnce([
+      { id: 'mat-1', projectId: 'proj-1', status: 'ready', metadata: {} },
+    ]);
+    mockSendConceptGraphExtractJob.mockResolvedValueOnce('job-xyz');
+
+    const request = new Request('http://localhost:3000/api/projects/proj-1/graph/extract', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ materialIds: ['mat-1'] }),
+    });
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'proj-1' }) });
+
+    expect(response.status).toBe(202);
+    const json = await response.json();
+    expect(json).toEqual({
+      enqueued: true,
+      materialCount: 1,
+      jobId: 'job-xyz',
+    });
+
+    // Verify status updated to queued
+    expect(mockUpdateMaterialStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'mat-1',
+        metadata: expect.objectContaining({
+          graphExtraction: expect.objectContaining({
+            status: 'queued',
+            jobId: 'job-xyz',
+          }),
+        }),
+      }),
+    );
+
+    // Verify job dispatched
+    expect(mockSendConceptGraphExtractJob).toHaveBeenCalledWith({
+      projectId: 'proj-1',
+      userId: 'user-1',
+      materialIds: ['mat-1'],
+    });
+  });
+
+  it('supports single materialId parameter format', async () => {
+    mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
+    mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', name: 'CS101', userId: 'user-1' });
+    mockGetMaterialsByProjectId.mockResolvedValueOnce([
+      { id: 'mat-2', projectId: 'proj-1', status: 'ready', metadata: {} },
+    ]);
+    mockSendConceptGraphExtractJob.mockResolvedValueOnce('job-abc');
+
+    const request = new Request('http://localhost:3000/api/projects/proj-1/graph/extract', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ materialId: 'mat-2' }),
+    });
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'proj-1' }) });
+
+    expect(response.status).toBe(202);
+    const json = await response.json();
+    expect(json.materialCount).toBe(1);
+    expect(json.jobId).toBe('job-abc');
+  });
+
+  it('defaults to all ready materials in project when materialIds is omitted', async () => {
+    mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
+    mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', name: 'CS101', userId: 'user-1' });
+    mockGetMaterialsByProjectId.mockResolvedValueOnce([
+      { id: 'mat-1', projectId: 'proj-1', status: 'ready', metadata: {} },
+      { id: 'mat-2', projectId: 'proj-1', status: 'ready', metadata: {} },
+      { id: 'mat-3', projectId: 'proj-1', status: 'processing', metadata: {} }, // Not ready
+    ]);
+    mockSendConceptGraphExtractJob.mockResolvedValueOnce('job-all');
+
+    const request = new Request('http://localhost:3000/api/projects/proj-1/graph/extract', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'proj-1' }) });
+
+    expect(response.status).toBe(202);
+    const json = await response.json();
+    expect(json.materialCount).toBe(2);
+    expect(mockSendConceptGraphExtractJob).toHaveBeenCalledWith({
+      projectId: 'proj-1',
+      userId: 'user-1',
+      materialIds: ['mat-1', 'mat-2'],
+    });
+  });
+});

--- a/app/api/projects/[id]/graph/extract/route.test.ts
+++ b/app/api/projects/[id]/graph/extract/route.test.ts
@@ -175,4 +175,33 @@ describe('POST /api/projects/[id]/graph/extract', () => {
       materialIds: ['mat-1', 'mat-2'],
     });
   });
+
+  it('handles singleton debouncing gracefully when extraction job is already queued/active', async () => {
+    mockRequireAuthUser.mockResolvedValueOnce(defaultUser);
+    mockGetProjectById.mockResolvedValueOnce({ id: 'proj-1', name: 'CS101', userId: 'user-1' });
+    mockGetMaterialsByProjectId.mockResolvedValueOnce([
+      { id: 'mat-1', projectId: 'proj-1', status: 'ready', metadata: {} },
+    ]);
+    // pg-boss debounces duplicate singletonKey by returning null
+    mockSendConceptGraphExtractJob.mockResolvedValueOnce(null);
+
+    const request = new Request('http://localhost:3000/api/projects/proj-1/graph/extract', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ materialIds: ['mat-1'] }),
+    });
+
+    const response = await POST(request, { params: Promise.resolve({ id: 'proj-1' }) });
+
+    expect(response.status).toBe(202);
+    const json = await response.json();
+    expect(json).toEqual({
+      enqueued: false,
+      materialCount: 1,
+      jobId: null,
+    });
+
+    // Material status should not be updated when debounced
+    expect(mockUpdateMaterialStatus).not.toHaveBeenCalled();
+  });
 });

--- a/app/api/projects/[id]/graph/extract/route.ts
+++ b/app/api/projects/[id]/graph/extract/route.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+import { requireAuthUser } from '@/lib/auth/session';
+import { getProjectById } from '@/lib/db/queries/project';
+import { ChatbotError } from '@/lib/errors';
+import { queueGraphExtraction } from '@/lib/materials/concept-extraction';
+
+export const maxDuration = 60;
+
+const extractGraphRequestSchema = z.object({
+  materialIds: z.array(z.string().trim().min(1)).min(1).optional(),
+  materialId: z.string().trim().min(1).optional(),
+});
+
+// biome-ignore lint/style/useNamingConvention: Next.js HTTP method export
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  try {
+    const { id: projectId } = await params;
+    const user = await requireAuthUser();
+
+    const project = await getProjectById({ id: projectId, userId: user.id });
+    if (!project) {
+      return new ChatbotError('not_found:chat', 'Project not found').toResponse();
+    }
+
+    const rawJson = await request.json().catch(() => ({}));
+    const parseResult = extractGraphRequestSchema.safeParse(rawJson);
+    if (!parseResult.success) {
+      return new ChatbotError(
+        'bad_request:api',
+        parseResult.error.issues[0]?.message ?? 'Invalid request payload',
+      ).toResponse();
+    }
+
+    const { materialIds, materialId } = parseResult.data;
+    const targetMaterialIds = materialIds ?? (materialId ? [materialId] : undefined);
+
+    const result = await queueGraphExtraction({
+      projectId,
+      userId: user.id,
+      materialIds: targetMaterialIds,
+    });
+
+    return Response.json(result, { status: 202 });
+  } catch (error) {
+    if (error instanceof ChatbotError) {
+      return error.toResponse();
+    }
+    return new ChatbotError('bad_request:api').toResponse();
+  }
+}

--- a/components/document/material-list.test.tsx
+++ b/components/document/material-list.test.tsx
@@ -1,0 +1,118 @@
+import { renderToString } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MaterialList } from './material-list';
+
+const mockUseMaterials = vi.fn();
+vi.mock('@/lib/hooks/use-materials', () => ({
+  useMaterials: (...args: unknown[]) => mockUseMaterials(...args),
+}));
+
+// Mock Dialogs to avoid Radix Portal / DOM issues in SSR
+vi.mock('@/components/document/delete-material-dialog', () => ({
+  // biome-ignore lint/style/useNamingConvention: React mock component export
+  DeleteMaterialDialog: () => null,
+}));
+vi.mock('@/components/document/material-preview-dialog', () => ({
+  // biome-ignore lint/style/useNamingConvention: React mock component export
+  MaterialPreviewDialog: () => null,
+}));
+vi.mock('@/components/document/material-upload-dialog', () => ({
+  // biome-ignore lint/style/useNamingConvention: React mock component export
+  MaterialUploadDialog: () => null,
+}));
+
+// Mock DropdownMenu components so items render inline for SSR testing
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  // biome-ignore lint/style/useNamingConvention: React mock component export
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  // biome-ignore lint/style/useNamingConvention: React mock component export
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  // biome-ignore lint/style/useNamingConvention: React mock component export
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  // biome-ignore lint/style/useNamingConvention: React mock component export
+  DropdownMenuItem: ({
+    children,
+    ...props
+  }: {
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => <div {...props}>{children}</div>,
+  // biome-ignore lint/style/useNamingConvention: React mock component export
+  DropdownMenuSeparator: () => <hr />,
+}));
+
+describe('MaterialList Component', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders "Extracting Graph..." badge with spinner when graphExtraction.status is queued or extracting', () => {
+    mockUseMaterials.mockReturnValue({
+      materials: [
+        {
+          id: 'mat-1',
+          title: 'Graph Theory.pdf',
+          fileType: 'application/pdf',
+          filename: 'graph.pdf',
+          status: 'ready',
+          metadata: {
+            graphExtraction: {
+              status: 'extracting',
+            },
+          },
+        },
+        {
+          id: 'mat-2',
+          title: 'Algorithms.md',
+          fileType: 'text/markdown',
+          filename: 'algo.md',
+          status: 'ready',
+          metadata: {
+            graphExtraction: {
+              status: 'queued',
+            },
+          },
+        },
+        {
+          id: 'mat-3',
+          title: 'Calculus.pdf',
+          fileType: 'application/pdf',
+          filename: 'calc.pdf',
+          status: 'ready',
+          metadata: {},
+        },
+      ],
+      isLoading: false,
+      mutate: vi.fn(),
+    });
+
+    const html = renderToString(<MaterialList projectId="proj-1" />);
+
+    expect(html).toContain('Extracting Graph...');
+    expect(html).toContain('material-extracting-graph-mat-1');
+    expect(html).toContain('material-extracting-graph-mat-2');
+    expect(html).not.toContain('material-extracting-graph-mat-3');
+  });
+
+  it('renders "Extract Concepts" action item in dropdown menu', () => {
+    mockUseMaterials.mockReturnValue({
+      materials: [
+        {
+          id: 'mat-1',
+          title: 'Physics.pdf',
+          fileType: 'application/pdf',
+          filename: 'physics.pdf',
+          status: 'ready',
+          metadata: {},
+        },
+      ],
+      isLoading: false,
+      mutate: vi.fn(),
+    });
+
+    const html = renderToString(<MaterialList projectId="proj-1" />);
+
+    expect(html).toContain('Extract Concepts');
+    expect(html).toContain('extract-concepts-option-mat-1');
+  });
+});

--- a/components/document/material-list.test.tsx
+++ b/components/document/material-list.test.tsx
@@ -115,4 +115,84 @@ describe('MaterialList Component', () => {
     expect(html).toContain('Extract Concepts');
     expect(html).toContain('extract-concepts-option-mat-1');
   });
+
+  describe('Sync Graph Button', () => {
+    it('renders "Sync Graph" button enabled in idle state with ready materials', () => {
+      mockUseMaterials.mockReturnValue({
+        materials: [
+          {
+            id: 'mat-1',
+            title: 'Doc.pdf',
+            fileType: 'application/pdf',
+            filename: 'doc.pdf',
+            status: 'ready',
+            metadata: {},
+          },
+        ],
+        isLoading: false,
+        mutate: vi.fn(),
+      });
+
+      const html = renderToString(<MaterialList projectId="proj-1" />);
+
+      expect(html).toContain('data-testid="sync-graph-button"');
+      expect(html).toContain('Sync Graph');
+      // In idle state, button should not have disabled attribute and should not have animate-spin on sync button
+      expect(html).toMatch(/<button[^>]*data-testid="sync-graph-button"(?![^>]*disabled)[^>]*>/);
+    });
+
+    it('renders "Sync Graph" button disabled with spinning indicator when any material is extracting', () => {
+      mockUseMaterials.mockReturnValue({
+        materials: [
+          {
+            id: 'mat-1',
+            title: 'Doc.pdf',
+            fileType: 'application/pdf',
+            filename: 'doc.pdf',
+            status: 'ready',
+            metadata: {
+              graphExtraction: {
+                status: 'extracting',
+              },
+            },
+          },
+        ],
+        isLoading: false,
+        mutate: vi.fn(),
+      });
+
+      const html = renderToString(<MaterialList projectId="proj-1" />);
+
+      expect(html).toContain('data-testid="sync-graph-button"');
+      expect(html).toMatch(/<button[^>]*data-testid="sync-graph-button"[^>]*disabled/);
+      expect(html).toContain('animate-spin');
+    });
+
+    it('renders "Sync Graph" button disabled with spinning indicator when any material is queued', () => {
+      mockUseMaterials.mockReturnValue({
+        materials: [
+          {
+            id: 'mat-1',
+            title: 'Doc.pdf',
+            fileType: 'application/pdf',
+            filename: 'doc.pdf',
+            status: 'ready',
+            metadata: {
+              graphExtraction: {
+                status: 'queued',
+              },
+            },
+          },
+        ],
+        isLoading: false,
+        mutate: vi.fn(),
+      });
+
+      const html = renderToString(<MaterialList projectId="proj-1" />);
+
+      expect(html).toContain('data-testid="sync-graph-button"');
+      expect(html).toMatch(/<button[^>]*data-testid="sync-graph-button"[^>]*disabled/);
+      expect(html).toContain('animate-spin');
+    });
+  });
 });

--- a/components/document/material-list.tsx
+++ b/components/document/material-list.tsx
@@ -10,9 +10,11 @@ import {
   FileText,
   Loader2,
   MoreVertical,
+  Network,
   Trash2,
   Upload,
 } from 'lucide-react';
+
 import { type ChangeEvent, useRef, useState } from 'react';
 import { DeleteMaterialDialog } from '@/components/document/delete-material-dialog';
 import { MaterialPreviewDialog } from '@/components/document/material-preview-dialog';
@@ -27,6 +29,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { type MaterialItem, type MaterialStatus, useMaterials } from '@/lib/hooks/use-materials';
+import { isMaterialExtractingGraph } from '@/lib/materials';
 import { ACCEPTED_FILE_TYPES_STRING, getFileIconType } from '@/lib/materials/validation';
 import { cn } from '@/lib/utils';
 
@@ -94,6 +97,7 @@ export function MaterialList({ projectId, className }: MaterialListProps) {
   const [deleteTargetMaterial, setDeleteTargetMaterial] = useState<MaterialItem | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const [extractError, setExtractError] = useState<string | null>(null);
 
   const { materials, isLoading, mutate } = useMaterials(projectId);
 
@@ -105,6 +109,28 @@ export function MaterialList({ projectId, className }: MaterialListProps) {
   const handleDeletePrompt = (material: MaterialItem) => {
     setDeleteTargetMaterial(material);
     setDeleteDialogOpen(true);
+  };
+
+  const handleExtractConcepts = async (materialId: string) => {
+    setExtractError(null);
+    try {
+      const response = await fetch(`/api/projects/${projectId}/graph/extract`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ materialIds: [materialId] }),
+      });
+
+      if (!response.ok) {
+        const errorJson = await response.json().catch(() => ({}));
+        throw new Error(
+          errorJson.cause || errorJson.message || 'Failed to trigger concept extraction',
+        );
+      }
+
+      await mutate();
+    } catch (err: unknown) {
+      setExtractError(err instanceof Error ? err.message : 'Failed to extract concepts');
+    }
   };
 
   // Direct file input handler (fallback / backward compat)
@@ -189,9 +215,9 @@ export function MaterialList({ projectId, className }: MaterialListProps) {
         </div>
 
         {/* Error Notice */}
-        {uploadError && (
+        {(uploadError || extractError) && (
           <div className="rounded bg-destructive/10 p-1.5 text-[11px] text-destructive">
-            {uploadError}
+            {uploadError || extractError}
           </div>
         )}
 
@@ -241,6 +267,17 @@ export function MaterialList({ projectId, className }: MaterialListProps) {
                 <div className="flex items-center gap-1 shrink-0">
                   {getStatusBadge(material.status, material.metadata?.progress?.stage)}
 
+                  {isMaterialExtractingGraph(material.metadata) && (
+                    <Badge
+                      variant="outline"
+                      className="gap-1 border-purple-500/30 bg-purple-500/10 text-purple-600 dark:text-purple-400 text-[10px] px-1.5 py-0 animate-pulse"
+                      data-testid={`material-extracting-graph-${material.id}`}
+                    >
+                      <Loader2 className="size-2.5 animate-spin" />
+                      <span>Extracting Graph...</span>
+                    </Badge>
+                  )}
+
                   {/* Actions Dropdown */}
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
@@ -266,6 +303,22 @@ export function MaterialList({ projectId, className }: MaterialListProps) {
                         <ExternalLink className="size-3.5 text-primary" />
                         <span>Inspect Chunks</span>
                       </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleExtractConcepts(material.id);
+                        }}
+                        disabled={
+                          material.status !== 'ready' ||
+                          isMaterialExtractingGraph(material.metadata)
+                        }
+                        className="gap-1.5 cursor-pointer text-xs"
+                        data-testid={`extract-concepts-option-${material.id}`}
+                      >
+                        <Network className="size-3.5 text-purple-500" />
+                        <span>Extract Concepts</span>
+                      </DropdownMenuItem>
+
                       <DropdownMenuSeparator />
                       <DropdownMenuItem
                         onClick={(e) => {

--- a/components/document/material-list.tsx
+++ b/components/document/material-list.tsx
@@ -11,6 +11,7 @@ import {
   Loader2,
   MoreVertical,
   Network,
+  RefreshCw,
   Trash2,
   Upload,
 } from 'lucide-react';
@@ -98,8 +99,11 @@ export function MaterialList({ projectId, className }: MaterialListProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [extractError, setExtractError] = useState<string | null>(null);
+  const [isSyncingGraph, setIsSyncingGraph] = useState(false);
 
   const { materials, isLoading, mutate } = useMaterials(projectId);
+
+  const isExtractingGraph = materials.some(isMaterialExtractingGraph);
 
   const handleInspect = (materialId: string) => {
     setPreviewMaterialId(materialId);
@@ -109,6 +113,31 @@ export function MaterialList({ projectId, className }: MaterialListProps) {
   const handleDeletePrompt = (material: MaterialItem) => {
     setDeleteTargetMaterial(material);
     setDeleteDialogOpen(true);
+  };
+
+  const handleSyncGraph = async () => {
+    setIsSyncingGraph(true);
+    setExtractError(null);
+    try {
+      const response = await fetch(`/api/projects/${projectId}/graph/extract`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      if (!response.ok) {
+        const errorJson = await response.json().catch(() => ({}));
+        throw new Error(
+          errorJson.cause || errorJson.message || 'Failed to trigger graph synchronization',
+        );
+      }
+
+      await mutate();
+    } catch (err: unknown) {
+      setExtractError(err instanceof Error ? err.message : 'Failed to synchronize graph');
+    } finally {
+      setIsSyncingGraph(false);
+    }
   };
 
   const handleExtractConcepts = async (materialId: string) => {
@@ -202,16 +231,34 @@ export function MaterialList({ projectId, className }: MaterialListProps) {
             data-testid="material-file-input"
           />
 
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-6 gap-1 px-1.5 text-xs text-muted-foreground hover:text-foreground"
-            onClick={() => setUploadDialogOpen(true)}
-            data-testid="upload-material-button"
-          >
-            <Upload className="size-3" />
-            <span>Upload</span>
-          </Button>
+          <div className="flex items-center gap-1">
+            <Button
+              data-testid="sync-graph-button"
+              variant="ghost"
+              size="sm"
+              className="h-6 gap-1 px-1.5 text-xs text-muted-foreground hover:text-foreground"
+              onClick={handleSyncGraph}
+              disabled={isExtractingGraph || isSyncingGraph}
+            >
+              {isExtractingGraph || isSyncingGraph ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <RefreshCw className="size-3" />
+              )}
+              <span>Sync Graph</span>
+            </Button>
+
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 gap-1 px-1.5 text-xs text-muted-foreground hover:text-foreground"
+              onClick={() => setUploadDialogOpen(true)}
+              data-testid="upload-material-button"
+            >
+              <Upload className="size-3" />
+              <span>Upload</span>
+            </Button>
+          </div>
         </div>
 
         {/* Error Notice */}

--- a/components/document/material-list.tsx
+++ b/components/document/material-list.tsx
@@ -30,7 +30,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { type MaterialItem, type MaterialStatus, useMaterials } from '@/lib/hooks/use-materials';
-import { isMaterialExtractingGraph } from '@/lib/materials';
+import { isMaterialExtractingGraph } from '@/lib/materials/types';
 import { ACCEPTED_FILE_TYPES_STRING, getFileIconType } from '@/lib/materials/validation';
 import { cn } from '@/lib/utils';
 

--- a/lib/ai/prompts.test.ts
+++ b/lib/ai/prompts.test.ts
@@ -9,6 +9,7 @@ import {
 describe('AI Prompts', () => {
   it('systemPrompt includes grounded tool instruction, citation format, and gap disclosure', () => {
     expect(systemPrompt).toContain('searchProjectMaterials');
+    expect(systemPrompt).toContain('getExercisesForKc');
     expect(systemPrompt).toContain('**[Material Title, Page X]**');
     expect(systemPrompt.toLowerCase()).toContain('missing');
   });

--- a/lib/ai/prompts.test.ts
+++ b/lib/ai/prompts.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { MATERIAL_VISION_INGESTION_PROMPT, systemPrompt, titlePrompt } from './prompts';
+import {
+  CONCEPT_GRAPH_EXTRACTION_PROMPT,
+  MATERIAL_VISION_INGESTION_PROMPT,
+  systemPrompt,
+  titlePrompt,
+} from './prompts';
 
 describe('AI Prompts', () => {
   it('systemPrompt includes grounded tool instruction, citation format, and gap disclosure', () => {
@@ -8,8 +13,10 @@ describe('AI Prompts', () => {
     expect(systemPrompt.toLowerCase()).toContain('missing');
   });
 
-  it('titlePrompt and MATERIAL_VISION_INGESTION_PROMPT are properly defined', () => {
+  it('titlePrompt, MATERIAL_VISION_INGESTION_PROMPT, and CONCEPT_GRAPH_EXTRACTION_PROMPT are properly defined', () => {
     expect(titlePrompt).toContain('Generate a short chat title');
     expect(MATERIAL_VISION_INGESTION_PROMPT).toContain('transcription engine');
+    expect(CONCEPT_GRAPH_EXTRACTION_PROMPT).toContain('pedagogical knowledge engineer');
+    expect(CONCEPT_GRAPH_EXTRACTION_PROMPT).toContain('PACER');
   });
 });

--- a/lib/ai/prompts.test.ts
+++ b/lib/ai/prompts.test.ts
@@ -28,4 +28,34 @@ describe('AI Prompts', () => {
     expect(CONCEPT_GRAPH_EXTRACTION_PROMPT).toMatch(/solution/i);
     expect(CONCEPT_GRAPH_EXTRACTION_PROMPT).toMatch(/unsolved|hallucinat/i);
   });
+
+  it('CONCEPT_GRAPH_EXTRACTION_PROMPT instructs LLM to reuse existing concept names', () => {
+    expect(CONCEPT_GRAPH_EXTRACTION_PROMPT).toContain(
+      'Reuse existing concept names whenever the text discusses a concept already in the vocabulary. Only create a new concept name if the concept is genuinely distinct.',
+    );
+  });
+
+  it('buildConceptExtractionPrompt formats prompt with existing vocabulary and grounding instruction', async () => {
+    const { buildConceptExtractionPrompt } = await import('./prompts');
+
+    const promptWithVocab = buildConceptExtractionPrompt({
+      content: 'Sample text about trees',
+      existingVocabulary: ['Binary Search Tree', 'AVL Tree'],
+    });
+
+    expect(promptWithVocab).toContain('Binary Search Tree');
+    expect(promptWithVocab).toContain('AVL Tree');
+    expect(promptWithVocab).toContain(
+      'Reuse existing concept names whenever the text discusses a concept already in the vocabulary. Only create a new concept name if the concept is genuinely distinct.',
+    );
+    expect(promptWithVocab).toContain('Sample text about trees');
+
+    const promptWithoutVocab = buildConceptExtractionPrompt({
+      content: 'Sample text about graphs',
+      existingVocabulary: [],
+    });
+
+    expect(promptWithoutVocab).not.toContain('Existing project concept vocabulary');
+    expect(promptWithoutVocab).toContain('Sample text about graphs');
+  });
 });

--- a/lib/ai/prompts.test.ts
+++ b/lib/ai/prompts.test.ts
@@ -19,4 +19,13 @@ describe('AI Prompts', () => {
     expect(CONCEPT_GRAPH_EXTRACTION_PROMPT).toContain('pedagogical knowledge engineer');
     expect(CONCEPT_GRAPH_EXTRACTION_PROMPT).toContain('PACER');
   });
+
+  it('CONCEPT_GRAPH_EXTRACTION_PROMPT contains practice problem and exercise extraction rules', () => {
+    expect(CONCEPT_GRAPH_EXTRACTION_PROMPT).toMatch(/exercises?|practice problems?/i);
+    expect(CONCEPT_GRAPH_EXTRACTION_PROMPT).toContain('pageNumber');
+    expect(CONCEPT_GRAPH_EXTRACTION_PROMPT).toContain('questionType');
+    expect(CONCEPT_GRAPH_EXTRACTION_PROMPT).toContain('difficulty');
+    expect(CONCEPT_GRAPH_EXTRACTION_PROMPT).toMatch(/solution/i);
+    expect(CONCEPT_GRAPH_EXTRACTION_PROMPT).toMatch(/unsolved|hallucinat/i);
+  });
 });

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -45,3 +45,24 @@ Follow these strict transcription rules:
 5. Handwritten Content: Transcribe all handwritten notes, margin annotations, and whiteboard drawings verbatim. Tag them with '> **Handwritten Note:** ...'.
 6. Equations: Transcribe mathematical expressions and chemical formulas in standard LaTeX notation ($inline$ or $$block$$).
 7. Noise Reduction: Omit recurring decorative page elements (slide template logos, page numbers in isolation) while keeping substantive footer notes.`.trim();
+
+export const CONCEPT_GRAPH_EXTRACTION_PROMPT = `You are an expert pedagogical knowledge engineer.
+Analyze the provided educational text and extract key teachable concepts (Knowledge Components) and their direct prerequisite dependencies.
+
+Rules:
+1. Concepts:
+   - Identify atomic, teachable concepts described in the text.
+   - Assign PACER category:
+     - 'procedural': algorithms, techniques, how-to problem-solving steps.
+     - 'analogous': comparisons, metaphors, mental models.
+     - 'conceptual': definitions, core theoretical principles, mental schemas.
+     - 'evidence': empirical observations, proofs, experimental results.
+     - 'reference': standardized tables, formulas, citations, specifications.
+   - Assign Bloom taxonomy cognitive depth level (1: Remember, 2: Understand, 3: Apply, 4: Analyze, 5: Evaluate, 6: Create).
+   - Provide aliases (synonyms, acronyms, common alternative names) if applicable.
+2. Prerequisites:
+   - A prerequisite relationship means sourceName must be understood BEFORE targetName can be learned.
+   - sourceName is the prerequisite; targetName is the dependent concept.
+   - Do NOT create self-loops (sourceName must not equal targetName).
+   - Only include relationships between concepts extracted from this text.
+   - Provide concise pedagogical reasoning for why source is a prerequisite for target.`.trim();

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -6,6 +6,7 @@ Guidelines for answering questions:
 1. Tool Usage & Grounding:
    - When answering questions about course concepts, project topics, uploaded slides, or study materials, invoke the \`searchProjectMaterials\` tool to search for relevant material chunks.
    - When assessing learner prerequisite knowledge, navigating learning trajectories, or exploring concept relationships, invoke the \`getGraphNeighborhood\` tool to explore direct prerequisites and unlocked concepts, or the \`getPrerequisiteChain\` tool to trace foundational ancestor prerequisite chains.
+   - When retrieving practice problems, exercises, self-checks, or drills for a concept, invoke the \`getExercisesForKc\` tool to discover grounded exercises with page citations and solutions.
    - Ground your explanations strictly in the retrieved project materials whenever available.
 
 2. Citations & Attribution:

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -65,4 +65,14 @@ Rules:
    - sourceName is the prerequisite; targetName is the dependent concept.
    - Do NOT create self-loops (sourceName must not equal targetName).
    - Only include relationships between concepts extracted from this text.
-   - Provide concise pedagogical reasoning for why source is a prerequisite for target.`.trim();
+   - Provide concise pedagogical reasoning for why source is a prerequisite for target.
+3. Exercises and Practice Problems:
+   - Extract practice problems, exercises, questions, and self-checks present in the text.
+   - For each exercise:
+     - Identify \`pageNumber\` in source material where exercise appears.
+     - Identify \`questionType\`: 'multiple_choice', 'calculation', 'conceptual', or 'code'.
+     - Assign \`difficulty\` on a scale of 1 to 5 (default 1).
+     - Provide optional \`title\` (e.g. "Problem 3.1", "Exercise 2").
+     - Provide optional \`prompt\` (text/LaTeX transcription of the problem statement).
+     - Provide \`solution\` ONLY if explicitly stated in the text. Omit solution if unsolved to avoid hallucinations.
+     - Identify \`targetConceptName\` indicating the concept that this exercise primarily tests.`.trim();

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -46,12 +46,16 @@ Follow these strict transcription rules:
 6. Equations: Transcribe mathematical expressions and chemical formulas in standard LaTeX notation ($inline$ or $$block$$).
 7. Noise Reduction: Omit recurring decorative page elements (slide template logos, page numbers in isolation) while keeping substantive footer notes.`.trim();
 
+export const VOCABULARY_GROUNDING_INSTRUCTION =
+  'Reuse existing concept names whenever the text discusses a concept already in the vocabulary. Only create a new concept name if the concept is genuinely distinct.';
+
 export const CONCEPT_GRAPH_EXTRACTION_PROMPT = `You are an expert pedagogical knowledge engineer.
 Analyze the provided educational text and extract key teachable concepts (Knowledge Components) and their direct prerequisite dependencies.
 
 Rules:
 1. Concepts:
    - Identify atomic, teachable concepts described in the text.
+   - ${VOCABULARY_GROUNDING_INSTRUCTION}
    - Assign PACER category:
      - 'procedural': algorithms, techniques, how-to problem-solving steps.
      - 'analogous': comparisons, metaphors, mental models.
@@ -76,3 +80,23 @@ Rules:
      - Provide optional \`prompt\` (text/LaTeX transcription of the problem statement).
      - Provide \`solution\` ONLY if explicitly stated in the text. Omit solution if unsolved to avoid hallucinations.
      - Identify \`targetConceptName\` indicating the concept that this exercise primarily tests.`.trim();
+
+export function buildConceptExtractionPrompt(options: {
+  content: string;
+  existingVocabulary?: string[];
+}): string {
+  const parts: string[] = [];
+
+  if (options.existingVocabulary && options.existingVocabulary.length > 0) {
+    const list = options.existingVocabulary.map((name) => `- ${name}`).join('\n');
+    parts.push(
+      `Existing project concept vocabulary:\n${list}\n\n${VOCABULARY_GROUNDING_INSTRUCTION}`,
+    );
+  }
+
+  parts.push(
+    `Extract knowledge concepts, prerequisite dependencies, and practice exercises/problems from the following educational material:\n\n${options.content}`,
+  );
+
+  return parts.join('\n\n');
+}

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -5,6 +5,7 @@ Your core mission is to help users learn actively, master complex concepts step-
 Guidelines for answering questions:
 1. Tool Usage & Grounding:
    - When answering questions about course concepts, project topics, uploaded slides, or study materials, invoke the \`searchProjectMaterials\` tool to search for relevant material chunks.
+   - When assessing learner prerequisite knowledge, navigating learning trajectories, or exploring concept relationships, invoke the \`getGraphNeighborhood\` tool to explore direct prerequisites and unlocked concepts, or the \`getPrerequisiteChain\` tool to trace foundational ancestor prerequisite chains.
    - Ground your explanations strictly in the retrieved project materials whenever available.
 
 2. Citations & Attribution:

--- a/lib/ai/tools.test.ts
+++ b/lib/ai/tools.test.ts
@@ -170,7 +170,7 @@ describe('AI Tools Registry (createTools)', () => {
     expect(output.results).toEqual([]);
   });
 
-  it('creates getGraphNeighborhood and getPrerequisiteChain tools with proper schemas', () => {
+  it('creates getGraphNeighborhood, getPrerequisiteChain, and getExercisesForKc tools with proper schemas', () => {
     const tools = createTools({
       projectId: 'proj-1',
       userId: 'user-1',
@@ -178,7 +178,9 @@ describe('AI Tools Registry (createTools)', () => {
 
     expect(tools).toHaveProperty('getGraphNeighborhood');
     expect(tools).toHaveProperty('getPrerequisiteChain');
+    expect(tools).toHaveProperty('getExercisesForKc');
     expect(tools.getGraphNeighborhood.description).toMatch(/neighborhood|prerequisites/i);
     expect(tools.getPrerequisiteChain.description).toMatch(/prerequisite|ancestor|chain/i);
+    expect(tools.getExercisesForKc.description).toMatch(/exercise|problem|practice/i);
   });
 });

--- a/lib/ai/tools.test.ts
+++ b/lib/ai/tools.test.ts
@@ -169,4 +169,16 @@ describe('AI Tools Registry (createTools)', () => {
     expect(output.error).toBe('Vector search failed');
     expect(output.results).toEqual([]);
   });
+
+  it('creates getGraphNeighborhood and getPrerequisiteChain tools with proper schemas', () => {
+    const tools = createTools({
+      projectId: 'proj-1',
+      userId: 'user-1',
+    });
+
+    expect(tools).toHaveProperty('getGraphNeighborhood');
+    expect(tools).toHaveProperty('getPrerequisiteChain');
+    expect(tools.getGraphNeighborhood.description).toMatch(/neighborhood|prerequisites/i);
+    expect(tools.getPrerequisiteChain.description).toMatch(/prerequisite|ancestor|chain/i);
+  });
 });

--- a/lib/ai/tools.ts
+++ b/lib/ai/tools.ts
@@ -2,7 +2,11 @@ import { tool } from 'ai';
 import { z } from 'zod';
 import type { GetEmbeddingModelOptions } from '@/lib/ai/embedding';
 import type { ProviderName } from '@/lib/ai/providers';
-import { createGraphNeighborhoodTool, createPrerequisiteChainTool } from '@/lib/ai/tools/graph';
+import {
+  createExercisesForKcTool,
+  createGraphNeighborhoodTool,
+  createPrerequisiteChainTool,
+} from '@/lib/ai/tools/graph';
 import { retrieveMaterials, type SearchMaterialsResult } from '@/lib/materials';
 
 export type ToolStatusData =
@@ -60,6 +64,23 @@ export type ToolStatusData =
       status: 'error';
       kcId: string;
       error: string;
+    }
+  | {
+      tool: 'getExercisesForKc';
+      status: 'searching';
+      kcId: string;
+    }
+  | {
+      tool: 'getExercisesForKc';
+      status: 'completed';
+      kcId: string;
+      exerciseCount: number;
+    }
+  | {
+      tool: 'getExercisesForKc';
+      status: 'error';
+      kcId: string;
+      error: string;
     };
 
 export type DataStreamWriter = {
@@ -93,6 +114,7 @@ export type ProjectTools = {
   searchProjectMaterials: ReturnType<typeof createSearchProjectMaterialsTool>;
   getGraphNeighborhood: ReturnType<typeof createGraphNeighborhoodTool>;
   getPrerequisiteChain: ReturnType<typeof createPrerequisiteChainTool>;
+  getExercisesForKc: ReturnType<typeof createExercisesForKcTool>;
 };
 
 function resolveEmbeddingOptions(
@@ -193,6 +215,7 @@ export function createTools(options: CreateToolsOptions): ProjectTools {
     searchProjectMaterials: createSearchProjectMaterialsTool(options),
     getGraphNeighborhood: createGraphNeighborhoodTool(options),
     getPrerequisiteChain: createPrerequisiteChainTool(options),
+    getExercisesForKc: createExercisesForKcTool(options),
   };
 }
 

--- a/lib/ai/tools.ts
+++ b/lib/ai/tools.ts
@@ -2,6 +2,7 @@ import { tool } from 'ai';
 import { z } from 'zod';
 import type { GetEmbeddingModelOptions } from '@/lib/ai/embedding';
 import type { ProviderName } from '@/lib/ai/providers';
+import { createGraphNeighborhoodTool, createPrerequisiteChainTool } from '@/lib/ai/tools/graph';
 import { retrieveMaterials, type SearchMaterialsResult } from '@/lib/materials';
 
 export type ToolStatusData =
@@ -20,6 +21,44 @@ export type ToolStatusData =
       tool: 'searchProjectMaterials';
       status: 'error';
       query: string;
+      error: string;
+    }
+  | {
+      tool: 'getGraphNeighborhood';
+      status: 'searching';
+      kcId: string;
+      depth?: number;
+    }
+  | {
+      tool: 'getGraphNeighborhood';
+      status: 'completed';
+      kcId: string;
+      depth: number;
+      prerequisitesCount: number;
+      unlockedCount: number;
+    }
+  | {
+      tool: 'getGraphNeighborhood';
+      status: 'error';
+      kcId: string;
+      error: string;
+    }
+  | {
+      tool: 'getPrerequisiteChain';
+      status: 'searching';
+      kcId: string;
+      maxDepth?: number;
+    }
+  | {
+      tool: 'getPrerequisiteChain';
+      status: 'completed';
+      kcId: string;
+      ancestorsCount: number;
+    }
+  | {
+      tool: 'getPrerequisiteChain';
+      status: 'error';
+      kcId: string;
       error: string;
     };
 
@@ -52,6 +91,8 @@ export type SearchProjectMaterialsResult =
 
 export type ProjectTools = {
   searchProjectMaterials: ReturnType<typeof createSearchProjectMaterialsTool>;
+  getGraphNeighborhood: ReturnType<typeof createGraphNeighborhoodTool>;
+  getPrerequisiteChain: ReturnType<typeof createPrerequisiteChainTool>;
 };
 
 function resolveEmbeddingOptions(
@@ -150,5 +191,9 @@ function createSearchProjectMaterialsTool({
 export function createTools(options: CreateToolsOptions): ProjectTools {
   return {
     searchProjectMaterials: createSearchProjectMaterialsTool(options),
+    getGraphNeighborhood: createGraphNeighborhoodTool(options),
+    getPrerequisiteChain: createPrerequisiteChainTool(options),
   };
 }
+
+export * from '@/lib/ai/tools/graph';

--- a/lib/ai/tools/graph.test.ts
+++ b/lib/ai/tools/graph.test.ts
@@ -1,9 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DataStreamWriter } from '@/lib/ai/tools';
 import {
+  createExercisesForKcTool,
   createGraphNeighborhoodTool,
   createPrerequisiteChainTool,
+  type ExercisesForKcToolResult,
   type GraphNeighborhoodToolResult,
+  getExercisesForKcTool,
   getGraphNeighborhoodTool,
   getPrerequisiteChainTool,
   type PrerequisiteChainToolResult,
@@ -11,10 +14,12 @@ import {
 
 const mockGetGraphNeighborhood = vi.fn();
 const mockGetPrerequisiteChain = vi.fn();
+const mockGetExercisesForKc = vi.fn();
 
 vi.mock('@/lib/db/queries/knowledge', () => ({
   getGraphNeighborhood: (...args: unknown[]) => mockGetGraphNeighborhood(...args),
   getPrerequisiteChain: (...args: unknown[]) => mockGetPrerequisiteChain(...args),
+  getExercisesForKc: (...args: unknown[]) => mockGetExercisesForKc(...args),
 }));
 
 function countApproximateTokens(text: string): number {
@@ -351,6 +356,198 @@ describe('Dual-Output Graph AI Tools (lib/ai/tools/graph.ts)', () => {
           error: 'CTE query timeout',
         },
       });
+    });
+  });
+
+  describe('createExercisesForKcTool / getExercisesForKcTool', () => {
+    it('aliases getExercisesForKcTool to createExercisesForKcTool', () => {
+      expect(getExercisesForKcTool).toBe(createExercisesForKcTool);
+    });
+
+    it('creates tool with appropriate description and input schema', () => {
+      const toolInstance = createExercisesForKcTool({
+        projectId: 'proj-1',
+        userId: 'user-1',
+      });
+
+      expect(toolInstance.description).toMatch(/exercise|problem|practice/i);
+      expect(toolInstance.inputSchema).toBeDefined();
+    });
+
+    it('executes tool returning Dual-Output Projection: terse summary (<= 15 tokens) and rich structured payload with pageNumber', async () => {
+      const mockDataStream: DataStreamWriter = { write: vi.fn() };
+      const sampleExercises = [
+        {
+          id: 'ex-1',
+          projectId: 'proj-1',
+          userId: 'user-1',
+          materialId: 'mat-1',
+          kcId: 'kc-1',
+          pageNumber: 12,
+          title: 'Problem 1.1',
+          prompt: 'Calculate 2 + 2',
+          solution: '4',
+          questionType: 'calculation' as const,
+          difficulty: 1,
+          createdAt: new Date(),
+        },
+        {
+          id: 'ex-2',
+          projectId: 'proj-1',
+          userId: 'user-1',
+          materialId: 'mat-1',
+          kcId: 'kc-1',
+          pageNumber: 15,
+          title: 'Problem 1.2',
+          prompt: 'Solve for x: x^2 = 16',
+          solution: 'x = 4 or -4',
+          questionType: 'calculation' as const,
+          difficulty: 2,
+          createdAt: new Date(),
+        },
+      ];
+
+      mockGetExercisesForKc.mockResolvedValueOnce(sampleExercises);
+
+      const toolInstance = createExercisesForKcTool({
+        projectId: 'proj-1',
+        userId: 'user-1',
+        dataStream: mockDataStream,
+      });
+
+      const result = (await toolInstance.execute(
+        { kcId: 'Algebra' },
+        { toolCallId: 'tc-ex-1', messages: [], context: {} },
+      )) as ExercisesForKcToolResult;
+
+      // 1. Dual-Output: Terse text summary bounded to <= 15 tokens
+      expect(result.summary).toBe('[OK: 2 exercises found for Algebra]');
+      expect(result.text).toBe('[OK: 2 exercises found for Algebra]');
+      expect(result.content).toBe('[OK: 2 exercises found for Algebra]');
+      expect(result.toString()).toBe('[OK: 2 exercises found for Algebra]');
+      expect(countApproximateTokens(result.summary)).toBeLessThanOrEqual(15);
+      expect(
+        toolInstance.toModelOutput?.({
+          toolCallId: 'tc-ex-1',
+          input: { kcId: 'Algebra' },
+          output: result,
+        }),
+      ).toEqual({
+        type: 'text',
+        value: '[OK: 2 exercises found for Algebra]',
+      });
+      expect(toolInstance.experimental_toToolResultContent?.(result)).toEqual([
+        { type: 'text', text: '[OK: 2 exercises found for Algebra]' },
+      ]);
+
+      // 2. Dual-Output: Rich client payload with pageNumber and fields
+      expect(result.exercises).toEqual(sampleExercises);
+      expect(result.exercises[0].pageNumber).toBe(12);
+      expect(result.exercises[1].pageNumber).toBe(15);
+      expect(result.payload).toEqual({
+        kcId: 'Algebra',
+        exercises: sampleExercises,
+        count: 2,
+      });
+
+      // 3. Streaming status events
+      expect(mockDataStream.write).toHaveBeenCalledWith({
+        type: 'data-tool-status',
+        data: {
+          tool: 'getExercisesForKc',
+          status: 'searching',
+          kcId: 'Algebra',
+        },
+      });
+      expect(mockDataStream.write).toHaveBeenCalledWith({
+        type: 'data-tool-status',
+        data: {
+          tool: 'getExercisesForKc',
+          status: 'completed',
+          kcId: 'Algebra',
+          exerciseCount: 2,
+        },
+      });
+    });
+
+    it('handles 0 exercises found gracefully with terse summary <= 15 tokens', async () => {
+      mockGetExercisesForKc.mockResolvedValueOnce([]);
+
+      const toolInstance = createExercisesForKcTool({
+        projectId: 'proj-1',
+      });
+
+      const result = (await toolInstance.execute(
+        { kcId: 'Calculus' },
+        { toolCallId: 'tc-ex-2', messages: [], context: {} },
+      )) as ExercisesForKcToolResult;
+
+      expect(result.summary).toBe('[OK: 0 exercises found for Calculus]');
+      expect(countApproximateTokens(result.summary)).toBeLessThanOrEqual(15);
+      expect(result.exercises).toEqual([]);
+      expect(result.payload.count).toBe(0);
+    });
+
+    it('handles missing projectId gracefully without calling DB query', async () => {
+      const toolInstance = createExercisesForKcTool({});
+
+      const result = (await toolInstance.execute(
+        { kcId: 'Algebra' },
+        { toolCallId: 'tc-ex-3', messages: [], context: {} },
+      )) as ExercisesForKcToolResult;
+
+      expect(result.summary).toBe('[Error: No project context]');
+      expect(countApproximateTokens(result.summary)).toBeLessThanOrEqual(15);
+      expect(mockGetExercisesForKc).not.toHaveBeenCalled();
+      expect(result.exercises).toEqual([]);
+    });
+
+    it('handles DB error gracefully and emits error status event', async () => {
+      const mockDataStream: DataStreamWriter = { write: vi.fn() };
+      mockGetExercisesForKc.mockRejectedValueOnce(new Error('Exercises query failure'));
+
+      const toolInstance = createExercisesForKcTool({
+        projectId: 'proj-1',
+        dataStream: mockDataStream,
+      });
+
+      const result = (await toolInstance.execute(
+        { kcId: 'Algebra' },
+        { toolCallId: 'tc-ex-4', messages: [], context: {} },
+      )) as ExercisesForKcToolResult;
+
+      expect(result.summary).toBe('[Error: Exercises query failure]');
+      expect(countApproximateTokens(result.summary)).toBeLessThanOrEqual(15);
+      expect(mockDataStream.write).toHaveBeenCalledWith({
+        type: 'data-tool-status',
+        data: {
+          tool: 'getExercisesForKc',
+          status: 'error',
+          kcId: 'Algebra',
+          error: 'Exercises query failure',
+        },
+      });
+      expect(result.exercises).toEqual([]);
+    });
+
+    it('bounds error summary strictly to <= 15 tokens even with long database error messages', async () => {
+      mockGetExercisesForKc.mockRejectedValueOnce(
+        new Error(
+          'Fatal database connection error: relation exercises does not exist at character 45 with code 42P01 and extra trace details',
+        ),
+      );
+
+      const toolInstance = createExercisesForKcTool({
+        projectId: 'proj-1',
+      });
+
+      const result = (await toolInstance.execute(
+        { kcId: 'Algebra' },
+        { toolCallId: 'tc-ex-5', messages: [], context: {} },
+      )) as ExercisesForKcToolResult;
+
+      expect(countApproximateTokens(result.summary)).toBeLessThanOrEqual(15);
+      expect(result.summary).toContain('...');
     });
   });
 });

--- a/lib/ai/tools/graph.test.ts
+++ b/lib/ai/tools/graph.test.ts
@@ -1,0 +1,356 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DataStreamWriter } from '@/lib/ai/tools';
+import {
+  createGraphNeighborhoodTool,
+  createPrerequisiteChainTool,
+  type GraphNeighborhoodToolResult,
+  getGraphNeighborhoodTool,
+  getPrerequisiteChainTool,
+  type PrerequisiteChainToolResult,
+} from './graph';
+
+const mockGetGraphNeighborhood = vi.fn();
+const mockGetPrerequisiteChain = vi.fn();
+
+vi.mock('@/lib/db/queries/knowledge', () => ({
+  getGraphNeighborhood: (...args: unknown[]) => mockGetGraphNeighborhood(...args),
+  getPrerequisiteChain: (...args: unknown[]) => mockGetPrerequisiteChain(...args),
+}));
+
+function countApproximateTokens(text: string): number {
+  return text.trim().split(/\s+/).length;
+}
+
+describe('Dual-Output Graph AI Tools (lib/ai/tools/graph.ts)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createGraphNeighborhoodTool / getGraphNeighborhoodTool', () => {
+    it('aliases getGraphNeighborhoodTool to createGraphNeighborhoodTool', () => {
+      expect(getGraphNeighborhoodTool).toBe(createGraphNeighborhoodTool);
+    });
+
+    it('creates tool with appropriate description and input schema', () => {
+      const toolInstance = createGraphNeighborhoodTool({
+        projectId: 'proj-1',
+        userId: 'user-1',
+      });
+
+      expect(toolInstance.description).toMatch(/neighborhood|prerequisites/i);
+      expect(toolInstance.inputSchema).toBeDefined();
+    });
+
+    it('executes tool returning Dual-Output Projection: terse summary (<= 15 tokens) and structured payload', async () => {
+      const mockDataStream: DataStreamWriter = { write: vi.fn() };
+      const centralConcept = {
+        id: 'kc-1',
+        projectId: 'proj-1',
+        slug: 'binary-search',
+        name: 'Binary Search',
+      };
+      const prereqs = [
+        { id: 'kc-p1', name: 'Arrays', depth: 1, relationshipType: 'prerequisite' },
+        { id: 'kc-p2', name: 'Divide and Conquer', depth: 1, relationshipType: 'prerequisite' },
+      ];
+      const unlocked = [
+        { id: 'kc-u1', name: 'Binary Search Tree', depth: 1, relationshipType: 'prerequisite' },
+      ];
+
+      mockGetGraphNeighborhood.mockResolvedValueOnce({
+        concept: centralConcept,
+        prerequisites: prereqs,
+        unlocked,
+        depth: 1,
+      });
+
+      const toolInstance = createGraphNeighborhoodTool({
+        projectId: 'proj-1',
+        userId: 'user-1',
+        dataStream: mockDataStream,
+      });
+
+      const result = (await toolInstance.execute(
+        { kcId: 'kc-1', depth: 1 },
+        { toolCallId: 'tc-1', messages: [], context: {} },
+      )) as GraphNeighborhoodToolResult;
+
+      // 1. Dual-Output Projection: Terse text summary <= 15 tokens
+      expect(result.summary).toBe('[OK: 2 prerequisites, 1 unlocked]');
+      expect(result.text).toBe('[OK: 2 prerequisites, 1 unlocked]');
+      expect(result.content).toBe('[OK: 2 prerequisites, 1 unlocked]');
+      expect(result.toString()).toBe('[OK: 2 prerequisites, 1 unlocked]');
+      expect(countApproximateTokens(result.summary)).toBeLessThanOrEqual(15);
+      expect(
+        toolInstance.toModelOutput?.({
+          toolCallId: 'tc-1',
+          input: { kcId: 'kc-1', depth: 1 },
+          output: result,
+        }),
+      ).toEqual({
+        type: 'text',
+        value: '[OK: 2 prerequisites, 1 unlocked]',
+      });
+      expect(toolInstance.experimental_toToolResultContent?.(result)).toEqual([
+        { type: 'text', text: '[OK: 2 prerequisites, 1 unlocked]' },
+      ]);
+
+      // 2. Dual-Output Projection: Rich structured JSON payload for client consumers
+      expect(result.payload).toEqual({
+        concept: centralConcept,
+        prerequisites: prereqs,
+        unlocked,
+        depth: 1,
+      });
+      expect(result.prerequisites).toEqual(prereqs);
+      expect(result.unlocked).toEqual(unlocked);
+      expect(result.concept).toEqual(centralConcept);
+
+      // 3. Streaming status events
+      expect(mockDataStream.write).toHaveBeenCalledWith({
+        type: 'data-tool-status',
+        data: {
+          tool: 'getGraphNeighborhood',
+          status: 'searching',
+          kcId: 'kc-1',
+          depth: 1,
+        },
+      });
+      expect(mockDataStream.write).toHaveBeenCalledWith({
+        type: 'data-tool-status',
+        data: {
+          tool: 'getGraphNeighborhood',
+          status: 'completed',
+          kcId: 'kc-1',
+          depth: 1,
+          prerequisitesCount: 2,
+          unlockedCount: 1,
+        },
+      });
+    });
+
+    it('handles concept not found gracefully with terse summary <= 15 tokens', async () => {
+      mockGetGraphNeighborhood.mockResolvedValueOnce({
+        concept: null,
+        prerequisites: [],
+        unlocked: [],
+        depth: 1,
+      });
+
+      const toolInstance = createGraphNeighborhoodTool({
+        projectId: 'proj-1',
+        userId: 'user-1',
+      });
+
+      const result = (await toolInstance.execute(
+        { kcId: 'unknown-id' },
+        { toolCallId: 'tc-2', messages: [], context: {} },
+      )) as GraphNeighborhoodToolResult;
+
+      expect(result.summary).toBe('[Error: Concept not found]');
+      expect(countApproximateTokens(result.summary)).toBeLessThanOrEqual(15);
+      expect(result.concept).toBeNull();
+      expect(result.prerequisites).toEqual([]);
+      expect(result.unlocked).toEqual([]);
+    });
+
+    it('handles missing projectId gracefully without calling DB query', async () => {
+      const toolInstance = createGraphNeighborhoodTool({
+        userId: 'user-1',
+      });
+
+      const result = (await toolInstance.execute(
+        { kcId: 'kc-1' },
+        { toolCallId: 'tc-3', messages: [], context: {} },
+      )) as GraphNeighborhoodToolResult;
+
+      expect(result.summary).toBe('[Error: No project context]');
+      expect(countApproximateTokens(result.summary)).toBeLessThanOrEqual(15);
+      expect(mockGetGraphNeighborhood).not.toHaveBeenCalled();
+    });
+
+    it('handles DB error gracefully and emits error status event', async () => {
+      const mockDataStream: DataStreamWriter = { write: vi.fn() };
+      mockGetGraphNeighborhood.mockRejectedValueOnce(new Error('Database query failure'));
+
+      const toolInstance = createGraphNeighborhoodTool({
+        projectId: 'proj-1',
+        dataStream: mockDataStream,
+      });
+
+      const result = (await toolInstance.execute(
+        { kcId: 'kc-1' },
+        { toolCallId: 'tc-4', messages: [], context: {} },
+      )) as GraphNeighborhoodToolResult;
+
+      expect(result.summary).toBe('[Error: Database query failure]');
+      expect(countApproximateTokens(result.summary)).toBeLessThanOrEqual(15);
+      expect(mockDataStream.write).toHaveBeenCalledWith({
+        type: 'data-tool-status',
+        data: {
+          tool: 'getGraphNeighborhood',
+          status: 'error',
+          kcId: 'kc-1',
+          error: 'Database query failure',
+        },
+      });
+    });
+  });
+
+  describe('createPrerequisiteChainTool / getPrerequisiteChainTool', () => {
+    it('aliases getPrerequisiteChainTool to createPrerequisiteChainTool', () => {
+      expect(getPrerequisiteChainTool).toBe(createPrerequisiteChainTool);
+    });
+
+    it('creates tool with appropriate description and input schema', () => {
+      const toolInstance = createPrerequisiteChainTool({
+        projectId: 'proj-1',
+        userId: 'user-1',
+      });
+
+      expect(toolInstance.description).toMatch(/prerequisite|ancestor|chain/i);
+      expect(toolInstance.inputSchema).toBeDefined();
+    });
+
+    it('executes tool returning Dual-Output Projection: terse summary (<= 15 tokens) and structured payload', async () => {
+      const mockDataStream: DataStreamWriter = { write: vi.fn() };
+      const chainNodes = [
+        {
+          id: 'kc-bfs',
+          name: 'Breadth-First Search',
+          slug: 'bfs',
+          depth: 1,
+          relationshipType: 'prerequisite',
+        },
+        {
+          id: 'kc-graphs',
+          name: 'Graphs',
+          slug: 'graphs',
+          depth: 2,
+          relationshipType: 'prerequisite',
+        },
+      ];
+
+      mockGetPrerequisiteChain.mockResolvedValueOnce(chainNodes);
+
+      const toolInstance = createPrerequisiteChainTool({
+        projectId: 'proj-1',
+        userId: 'user-1',
+        dataStream: mockDataStream,
+      });
+
+      const result = (await toolInstance.execute(
+        { kcId: 'kc-dijkstra', maxDepth: 10 },
+        { toolCallId: 'tc-5', messages: [], context: {} },
+      )) as PrerequisiteChainToolResult;
+
+      // 1. Dual-Output Projection: Terse text summary <= 15 tokens
+      expect(result.summary).toBe('[OK: 2 prerequisite ancestors]');
+      expect(result.text).toBe('[OK: 2 prerequisite ancestors]');
+      expect(result.content).toBe('[OK: 2 prerequisite ancestors]');
+      expect(result.toString()).toBe('[OK: 2 prerequisite ancestors]');
+      expect(countApproximateTokens(result.summary)).toBeLessThanOrEqual(15);
+      expect(
+        toolInstance.toModelOutput?.({
+          toolCallId: 'tc-5',
+          input: { kcId: 'kc-dijkstra', maxDepth: 10 },
+          output: result,
+        }),
+      ).toEqual({
+        type: 'text',
+        value: '[OK: 2 prerequisite ancestors]',
+      });
+      expect(toolInstance.experimental_toToolResultContent?.(result)).toEqual([
+        { type: 'text', text: '[OK: 2 prerequisite ancestors]' },
+      ]);
+
+      // 2. Dual-Output Projection: Rich structured JSON payload for client consumers
+      expect(result.payload).toEqual({
+        kcId: 'kc-dijkstra',
+        chain: chainNodes,
+        ancestors: chainNodes,
+        depth: 2,
+        count: 2,
+      });
+      expect(result.chain).toEqual(chainNodes);
+      expect(result.ancestors).toEqual(chainNodes);
+
+      // 3. Streaming status events
+      expect(mockDataStream.write).toHaveBeenCalledWith({
+        type: 'data-tool-status',
+        data: {
+          tool: 'getPrerequisiteChain',
+          status: 'searching',
+          kcId: 'kc-dijkstra',
+          maxDepth: 10,
+        },
+      });
+      expect(mockDataStream.write).toHaveBeenCalledWith({
+        type: 'data-tool-status',
+        data: {
+          tool: 'getPrerequisiteChain',
+          status: 'completed',
+          kcId: 'kc-dijkstra',
+          ancestorsCount: 2,
+        },
+      });
+    });
+
+    it('handles empty chain (no prerequisites) gracefully with terse summary <= 15 tokens', async () => {
+      mockGetPrerequisiteChain.mockResolvedValueOnce([]);
+
+      const toolInstance = createPrerequisiteChainTool({
+        projectId: 'proj-1',
+      });
+
+      const result = (await toolInstance.execute(
+        { kcId: 'kc-root' },
+        { toolCallId: 'tc-6', messages: [], context: {} },
+      )) as PrerequisiteChainToolResult;
+
+      expect(result.summary).toBe('[OK: 0 prerequisite ancestors]');
+      expect(countApproximateTokens(result.summary)).toBeLessThanOrEqual(15);
+      expect(result.chain).toEqual([]);
+    });
+
+    it('handles missing projectId gracefully without calling DB query', async () => {
+      const toolInstance = createPrerequisiteChainTool({});
+
+      const result = (await toolInstance.execute(
+        { kcId: 'kc-1' },
+        { toolCallId: 'tc-7', messages: [], context: {} },
+      )) as PrerequisiteChainToolResult;
+
+      expect(result.summary).toBe('[Error: No project context]');
+      expect(countApproximateTokens(result.summary)).toBeLessThanOrEqual(15);
+      expect(mockGetPrerequisiteChain).not.toHaveBeenCalled();
+    });
+
+    it('handles DB error gracefully and emits error status event', async () => {
+      const mockDataStream: DataStreamWriter = { write: vi.fn() };
+      mockGetPrerequisiteChain.mockRejectedValueOnce(new Error('CTE query timeout'));
+
+      const toolInstance = createPrerequisiteChainTool({
+        projectId: 'proj-1',
+        dataStream: mockDataStream,
+      });
+
+      const result = (await toolInstance.execute(
+        { kcId: 'kc-1' },
+        { toolCallId: 'tc-8', messages: [], context: {} },
+      )) as PrerequisiteChainToolResult;
+
+      expect(result.summary).toBe('[Error: CTE query timeout]');
+      expect(countApproximateTokens(result.summary)).toBeLessThanOrEqual(15);
+      expect(mockDataStream.write).toHaveBeenCalledWith({
+        type: 'data-tool-status',
+        data: {
+          tool: 'getPrerequisiteChain',
+          status: 'error',
+          kcId: 'kc-1',
+          error: 'CTE query timeout',
+        },
+      });
+    });
+  });
+});

--- a/lib/ai/tools/graph.ts
+++ b/lib/ai/tools/graph.ts
@@ -1,0 +1,390 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import type { CreateToolsOptions } from '@/lib/ai/tools';
+import {
+  type GraphNeighborKC,
+  getGraphNeighborhood,
+  getPrerequisiteChain,
+  type PrerequisiteChainNode,
+} from '@/lib/db/queries/knowledge';
+import type { KnowledgeComponent } from '@/lib/db/schema';
+
+export type GraphNeighborhoodToolResult = {
+  summary: string;
+  text: string;
+  content: string;
+  concept: KnowledgeComponent | null;
+  prerequisites: GraphNeighborKC[];
+  unlocked: GraphNeighborKC[];
+  depth: number;
+  payload: {
+    concept: KnowledgeComponent | null;
+    prerequisites: GraphNeighborKC[];
+    unlocked: GraphNeighborKC[];
+    depth: number;
+  };
+  error?: string;
+  toString: () => string;
+};
+
+export type PrerequisiteChainToolResult = {
+  summary: string;
+  text: string;
+  content: string;
+  concept: KnowledgeComponent | null;
+  chain: PrerequisiteChainNode[];
+  ancestors: PrerequisiteChainNode[];
+  depth: number;
+  payload: {
+    kcId: string;
+    chain: PrerequisiteChainNode[];
+    ancestors: PrerequisiteChainNode[];
+    depth: number;
+    count: number;
+  };
+  error?: string;
+  toString: () => string;
+};
+
+function formatNeighborhoodSummary(prereqsCount: number, unlockedCount: number): string {
+  const pWord = prereqsCount === 1 ? 'prerequisite' : 'prerequisites';
+  return `[OK: ${prereqsCount} ${pWord}, ${unlockedCount} unlocked]`;
+}
+
+function formatChainSummary(chainCount: number): string {
+  const aWord = chainCount === 1 ? 'prerequisite ancestor' : 'prerequisite ancestors';
+  return `[OK: ${chainCount} ${aWord}]`;
+}
+
+export function createGraphNeighborhoodTool({ projectId, dataStream }: CreateToolsOptions) {
+  const neighborhoodTool = tool({
+    description:
+      'Retrieve concept graph neighborhood including direct prerequisites and unlocked/dependent concepts, with optional 2-hop expansion.',
+    inputSchema: z.object({
+      kcId: z
+        .string()
+        .min(1)
+        .describe('The concept ID, slug, or name to inspect in the knowledge graph'),
+      depth: z
+        .number()
+        .int()
+        .min(1)
+        .max(2)
+        .optional()
+        .describe(
+          'Neighborhood expansion depth: 1 for direct neighbors, 2 for up to 2-hop neighbors (default: 1)',
+        ),
+    }),
+    toModelOutput: ({ output }) => ({
+      type: 'text' as const,
+      value: output.summary,
+    }),
+    execute: async ({
+      kcId,
+      depth = 1,
+    }: {
+      kcId: string;
+      depth?: number;
+    }): Promise<GraphNeighborhoodToolResult> => {
+      try {
+        dataStream?.write({
+          type: 'data-tool-status',
+          data: {
+            tool: 'getGraphNeighborhood',
+            status: 'searching',
+            kcId,
+            depth,
+          },
+        });
+
+        if (!projectId) {
+          const errorSummary = '[Error: No project context]';
+          return {
+            summary: errorSummary,
+            text: errorSummary,
+            content: errorSummary,
+            concept: null,
+            prerequisites: [],
+            unlocked: [],
+            depth,
+            payload: {
+              concept: null,
+              prerequisites: [],
+              unlocked: [],
+              depth,
+            },
+            error: 'No project context available for graph neighborhood.',
+            toString() {
+              return errorSummary;
+            },
+          };
+        }
+
+        const neighborhood = await getGraphNeighborhood({
+          projectId,
+          kcId,
+          depth,
+        });
+
+        if (!neighborhood.concept) {
+          const notFoundSummary = '[Error: Concept not found]';
+          return {
+            summary: notFoundSummary,
+            text: notFoundSummary,
+            content: notFoundSummary,
+            concept: null,
+            prerequisites: [],
+            unlocked: [],
+            depth,
+            payload: {
+              concept: null,
+              prerequisites: [],
+              unlocked: [],
+              depth,
+            },
+            error: `Concept "${kcId}" was not found in the project concept graph.`,
+            toString() {
+              return notFoundSummary;
+            },
+          };
+        }
+
+        const summary = formatNeighborhoodSummary(
+          neighborhood.prerequisites.length,
+          neighborhood.unlocked.length,
+        );
+
+        dataStream?.write({
+          type: 'data-tool-status',
+          data: {
+            tool: 'getGraphNeighborhood',
+            status: 'completed',
+            kcId,
+            depth: neighborhood.depth,
+            prerequisitesCount: neighborhood.prerequisites.length,
+            unlockedCount: neighborhood.unlocked.length,
+          },
+        });
+
+        return {
+          summary,
+          text: summary,
+          content: summary,
+          concept: neighborhood.concept,
+          prerequisites: neighborhood.prerequisites,
+          unlocked: neighborhood.unlocked,
+          depth: neighborhood.depth,
+          payload: {
+            concept: neighborhood.concept,
+            prerequisites: neighborhood.prerequisites,
+            unlocked: neighborhood.unlocked,
+            depth: neighborhood.depth,
+          },
+          toString() {
+            return summary;
+          },
+        };
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : 'Unknown graph query error';
+        const errorSummary = `[Error: ${errorMessage}]`;
+
+        dataStream?.write({
+          type: 'data-tool-status',
+          data: {
+            tool: 'getGraphNeighborhood',
+            status: 'error',
+            kcId,
+            error: errorMessage,
+          },
+        });
+
+        return {
+          summary: errorSummary,
+          text: errorSummary,
+          content: errorSummary,
+          concept: null,
+          prerequisites: [],
+          unlocked: [],
+          depth,
+          payload: {
+            concept: null,
+            prerequisites: [],
+            unlocked: [],
+            depth,
+          },
+          error: errorMessage,
+          toString() {
+            return errorSummary;
+          },
+        };
+      }
+    },
+  });
+
+  return Object.assign(neighborhoodTool, {
+    // biome-ignore lint/style/useNamingConvention: legacy AI SDK compatibility
+    experimental_toToolResultContent: (result: GraphNeighborhoodToolResult) => [
+      {
+        type: 'text' as const,
+        text: result.summary,
+      },
+    ],
+  });
+}
+
+export const getGraphNeighborhoodTool = createGraphNeighborhoodTool;
+
+export function createPrerequisiteChainTool({ projectId, dataStream }: CreateToolsOptions) {
+  const chainTool = tool({
+    description:
+      'Retrieve cycle-guarded recursive prerequisite ancestor chain for a concept, ordered from immediate to foundational prerequisites.',
+    inputSchema: z.object({
+      kcId: z
+        .string()
+        .min(1)
+        .describe('The concept ID, slug, or name to find prerequisite ancestors for'),
+      maxDepth: z
+        .number()
+        .int()
+        .min(1)
+        .max(20)
+        .optional()
+        .describe('Maximum recursion depth for prerequisite chain traversal (default: 10)'),
+    }),
+    toModelOutput: ({ output }) => ({
+      type: 'text' as const,
+      value: output.summary,
+    }),
+    execute: async ({
+      kcId,
+      maxDepth = 10,
+    }: {
+      kcId: string;
+      maxDepth?: number;
+    }): Promise<PrerequisiteChainToolResult> => {
+      try {
+        dataStream?.write({
+          type: 'data-tool-status',
+          data: {
+            tool: 'getPrerequisiteChain',
+            status: 'searching',
+            kcId,
+            maxDepth,
+          },
+        });
+
+        if (!projectId) {
+          const errorSummary = '[Error: No project context]';
+          return {
+            summary: errorSummary,
+            text: errorSummary,
+            content: errorSummary,
+            concept: null,
+            chain: [],
+            ancestors: [],
+            depth: 0,
+            payload: {
+              kcId,
+              chain: [],
+              ancestors: [],
+              depth: 0,
+              count: 0,
+            },
+            error: 'No project context available for prerequisite chain.',
+            toString() {
+              return errorSummary;
+            },
+          };
+        }
+
+        const chain = await getPrerequisiteChain({
+          projectId,
+          kcId,
+          maxDepth,
+        });
+
+        const maxObservedDepth = chain.length > 0 ? Math.max(...chain.map((c) => c.depth)) : 0;
+        const summary = formatChainSummary(chain.length);
+
+        dataStream?.write({
+          type: 'data-tool-status',
+          data: {
+            tool: 'getPrerequisiteChain',
+            status: 'completed',
+            kcId,
+            ancestorsCount: chain.length,
+          },
+        });
+
+        return {
+          summary,
+          text: summary,
+          content: summary,
+          concept: null,
+          chain,
+          ancestors: chain,
+          depth: maxObservedDepth,
+          payload: {
+            kcId,
+            chain,
+            ancestors: chain,
+            depth: maxObservedDepth,
+            count: chain.length,
+          },
+          toString() {
+            return summary;
+          },
+        };
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : 'Unknown chain query error';
+        const errorSummary = `[Error: ${errorMessage}]`;
+
+        dataStream?.write({
+          type: 'data-tool-status',
+          data: {
+            tool: 'getPrerequisiteChain',
+            status: 'error',
+            kcId,
+            error: errorMessage,
+          },
+        });
+
+        return {
+          summary: errorSummary,
+          text: errorSummary,
+          content: errorSummary,
+          concept: null,
+          chain: [],
+          ancestors: [],
+          depth: 0,
+          payload: {
+            kcId,
+            chain: [],
+            ancestors: [],
+            depth: 0,
+            count: 0,
+          },
+          error: errorMessage,
+          toString() {
+            return errorSummary;
+          },
+        };
+      }
+    },
+  });
+
+  return Object.assign(chainTool, {
+    // biome-ignore lint/style/useNamingConvention: legacy AI SDK compatibility
+    experimental_toToolResultContent: (result: PrerequisiteChainToolResult) => [
+      {
+        type: 'text' as const,
+        text: result.summary,
+      },
+    ],
+  });
+}
+
+export const getPrerequisiteChainTool = createPrerequisiteChainTool;
+
+export type GraphNeighborhoodTool = ReturnType<typeof createGraphNeighborhoodTool>;
+export type PrerequisiteChainTool = ReturnType<typeof createPrerequisiteChainTool>;

--- a/lib/ai/tools/graph.ts
+++ b/lib/ai/tools/graph.ts
@@ -3,11 +3,12 @@ import { z } from 'zod';
 import type { CreateToolsOptions } from '@/lib/ai/tools';
 import {
   type GraphNeighborKC,
+  getExercisesForKc,
   getGraphNeighborhood,
   getPrerequisiteChain,
   type PrerequisiteChainNode,
 } from '@/lib/db/queries/knowledge';
-import type { KnowledgeComponent } from '@/lib/db/schema';
+import type { Exercise, KnowledgeComponent } from '@/lib/db/schema';
 
 export type GraphNeighborhoodToolResult = {
   summary: string;
@@ -46,6 +47,21 @@ export type PrerequisiteChainToolResult = {
   toString: () => string;
 };
 
+export type ExercisesForKcToolResult = {
+  summary: string;
+  text: string;
+  content: string;
+  kcId: string;
+  exercises: Exercise[];
+  payload: {
+    kcId: string;
+    exercises: Exercise[];
+    count: number;
+  };
+  error?: string;
+  toString: () => string;
+};
+
 function formatNeighborhoodSummary(prereqsCount: number, unlockedCount: number): string {
   const pWord = prereqsCount === 1 ? 'prerequisite' : 'prerequisites';
   return `[OK: ${prereqsCount} ${pWord}, ${unlockedCount} unlocked]`;
@@ -54,6 +70,19 @@ function formatNeighborhoodSummary(prereqsCount: number, unlockedCount: number):
 function formatChainSummary(chainCount: number): string {
   const aWord = chainCount === 1 ? 'prerequisite ancestor' : 'prerequisite ancestors';
   return `[OK: ${chainCount} ${aWord}]`;
+}
+
+function formatExercisesSummary(count: number, kcId: string): string {
+  const eWord = count === 1 ? 'exercise' : 'exercises';
+  const cleanId = kcId.trim().replace(/\s+/g, ' ');
+  const truncatedId = cleanId.length > 25 ? `${cleanId.slice(0, 22)}...` : cleanId;
+  return `[OK: ${count} ${eWord} found for ${truncatedId}]`;
+}
+
+function formatErrorSummary(errorMessage: string): string {
+  const clean = errorMessage.trim().replace(/\s+/g, ' ');
+  const truncated = clean.length > 30 ? `${clean.slice(0, 27)}...` : clean;
+  return `[Error: ${truncated}]`;
 }
 
 export function createGraphNeighborhoodTool({ projectId, dataStream }: CreateToolsOptions) {
@@ -386,5 +415,130 @@ export function createPrerequisiteChainTool({ projectId, dataStream }: CreateToo
 
 export const getPrerequisiteChainTool = createPrerequisiteChainTool;
 
+export function createExercisesForKcTool({ projectId, dataStream }: CreateToolsOptions) {
+  const exercisesTool = tool({
+    description:
+      'Retrieve grounded practice exercises and problems for a knowledge component or concept, including page numbers, prompts, and solutions.',
+    inputSchema: z.object({
+      kcId: z
+        .string()
+        .min(1)
+        .describe('The concept ID, slug, or name to find practice exercises for'),
+    }),
+    toModelOutput: ({ output }) => ({
+      type: 'text' as const,
+      value: output.summary,
+    }),
+    execute: async ({ kcId }: { kcId: string }): Promise<ExercisesForKcToolResult> => {
+      try {
+        dataStream?.write({
+          type: 'data-tool-status',
+          data: {
+            tool: 'getExercisesForKc',
+            status: 'searching',
+            kcId,
+          },
+        });
+
+        if (!projectId) {
+          const errorSummary = '[Error: No project context]';
+          return {
+            summary: errorSummary,
+            text: errorSummary,
+            content: errorSummary,
+            kcId,
+            exercises: [],
+            payload: {
+              kcId,
+              exercises: [],
+              count: 0,
+            },
+            error: 'No project context available for exercises query.',
+            toString() {
+              return errorSummary;
+            },
+          };
+        }
+
+        const exercises = await getExercisesForKc({
+          projectId,
+          kcId,
+        });
+
+        const summary = formatExercisesSummary(exercises.length, kcId);
+
+        dataStream?.write({
+          type: 'data-tool-status',
+          data: {
+            tool: 'getExercisesForKc',
+            status: 'completed',
+            kcId,
+            exerciseCount: exercises.length,
+          },
+        });
+
+        return {
+          summary,
+          text: summary,
+          content: summary,
+          kcId,
+          exercises,
+          payload: {
+            kcId,
+            exercises,
+            count: exercises.length,
+          },
+          toString() {
+            return summary;
+          },
+        };
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : 'Unknown exercises query error';
+        const errorSummary = formatErrorSummary(errorMessage);
+
+        dataStream?.write({
+          type: 'data-tool-status',
+          data: {
+            tool: 'getExercisesForKc',
+            status: 'error',
+            kcId,
+            error: errorMessage,
+          },
+        });
+
+        return {
+          summary: errorSummary,
+          text: errorSummary,
+          content: errorSummary,
+          kcId,
+          exercises: [],
+          payload: {
+            kcId,
+            exercises: [],
+            count: 0,
+          },
+          error: errorMessage,
+          toString() {
+            return errorSummary;
+          },
+        };
+      }
+    },
+  });
+
+  return Object.assign(exercisesTool, {
+    // biome-ignore lint/style/useNamingConvention: legacy AI SDK compatibility
+    experimental_toToolResultContent: (result: ExercisesForKcToolResult) => [
+      {
+        type: 'text' as const,
+        text: result.summary,
+      },
+    ],
+  });
+}
+
+export const getExercisesForKcTool = createExercisesForKcTool;
+
 export type GraphNeighborhoodTool = ReturnType<typeof createGraphNeighborhoodTool>;
 export type PrerequisiteChainTool = ReturnType<typeof createPrerequisiteChainTool>;
+export type ExercisesForKcTool = ReturnType<typeof createExercisesForKcTool>;

--- a/lib/db/migrations/0005_first_firestar.sql
+++ b/lib/db/migrations/0005_first_firestar.sql
@@ -1,0 +1,41 @@
+CREATE TABLE "knowledge_components" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"project_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"slug" text NOT NULL,
+	"name" text NOT NULL,
+	"pacer_category" text NOT NULL,
+	"bloom_level" integer NOT NULL,
+	"aliases" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"embedding" vector(768),
+	"source_material_id" uuid,
+	"status" text DEFAULT 'active' NOT NULL,
+	"order_index" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "knowledge_dependencies" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"project_id" uuid NOT NULL,
+	"source_kc_id" uuid NOT NULL,
+	"target_kc_id" uuid NOT NULL,
+	"relationship_type" text DEFAULT 'prerequisite' NOT NULL,
+	"reasoning" text,
+	"is_transitive" boolean DEFAULT false NOT NULL,
+	"source_material_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "knowledge_components" ADD CONSTRAINT "knowledge_components_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "knowledge_components" ADD CONSTRAINT "knowledge_components_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "auth"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "knowledge_components" ADD CONSTRAINT "knowledge_components_source_material_id_materials_id_fk" FOREIGN KEY ("source_material_id") REFERENCES "public"."materials"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "knowledge_dependencies" ADD CONSTRAINT "knowledge_dependencies_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "knowledge_dependencies" ADD CONSTRAINT "knowledge_dependencies_source_kc_id_knowledge_components_id_fk" FOREIGN KEY ("source_kc_id") REFERENCES "public"."knowledge_components"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "knowledge_dependencies" ADD CONSTRAINT "knowledge_dependencies_target_kc_id_knowledge_components_id_fk" FOREIGN KEY ("target_kc_id") REFERENCES "public"."knowledge_components"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "knowledge_dependencies" ADD CONSTRAINT "knowledge_dependencies_source_material_id_materials_id_fk" FOREIGN KEY ("source_material_id") REFERENCES "public"."materials"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_kc_project_slug" ON "knowledge_components" USING btree ("project_id","slug");--> statement-breakpoint
+CREATE INDEX "idx_kc_project_id" ON "knowledge_components" USING btree ("project_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_kd_project_source_target_rel" ON "knowledge_dependencies" USING btree ("project_id","source_kc_id","target_kc_id","relationship_type");--> statement-breakpoint
+CREATE INDEX "idx_kd_project_target" ON "knowledge_dependencies" USING btree ("project_id","target_kc_id");--> statement-breakpoint
+CREATE INDEX "idx_kd_project_source" ON "knowledge_dependencies" USING btree ("project_id","source_kc_id");

--- a/lib/db/migrations/0006_mushy_the_hood.sql
+++ b/lib/db/migrations/0006_mushy_the_hood.sql
@@ -1,0 +1,22 @@
+CREATE TABLE "exercises" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"project_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"material_id" uuid NOT NULL,
+	"kc_id" uuid NOT NULL,
+	"page_number" integer NOT NULL,
+	"title" text,
+	"prompt" text,
+	"solution" text,
+	"question_type" text NOT NULL,
+	"difficulty" integer DEFAULT 1 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "exercises" ADD CONSTRAINT "exercises_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "exercises" ADD CONSTRAINT "exercises_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "auth"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "exercises" ADD CONSTRAINT "exercises_material_id_materials_id_fk" FOREIGN KEY ("material_id") REFERENCES "public"."materials"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "exercises" ADD CONSTRAINT "exercises_kc_id_knowledge_components_id_fk" FOREIGN KEY ("kc_id") REFERENCES "public"."knowledge_components"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_exercises_project" ON "exercises" USING btree ("project_id");--> statement-breakpoint
+CREATE INDEX "idx_exercises_material" ON "exercises" USING btree ("material_id");--> statement-breakpoint
+CREATE INDEX "idx_exercises_kc" ON "exercises" USING btree ("kc_id");

--- a/lib/db/migrations/meta/0005_snapshot.json
+++ b/lib/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,1016 @@
+{
+  "id": "e9d1b9d5-3ceb-434f-b4db-2cf5db8eaf33",
+  "prevId": "6078df61-b24e-4c0a-9dd6-0e4f03ae251e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chats_user_id_users_id_fk": {
+          "name": "chats_user_id_users_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chats_project_id_projects_id_fk": {
+          "name": "chats_project_id_projects_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": ["chat_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.knowledge_components": {
+      "name": "knowledge_components",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pacer_category": {
+          "name": "pacer_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bloom_level": {
+          "name": "bloom_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_material_id": {
+          "name": "source_material_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kc_project_slug": {
+          "name": "idx_kc_project_slug",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kc_project_id": {
+          "name": "idx_kc_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "knowledge_components_project_id_projects_id_fk": {
+          "name": "knowledge_components_project_id_projects_id_fk",
+          "tableFrom": "knowledge_components",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_components_user_id_users_id_fk": {
+          "name": "knowledge_components_user_id_users_id_fk",
+          "tableFrom": "knowledge_components",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_components_source_material_id_materials_id_fk": {
+          "name": "knowledge_components_source_material_id_materials_id_fk",
+          "tableFrom": "knowledge_components",
+          "tableTo": "materials",
+          "columnsFrom": ["source_material_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.knowledge_dependencies": {
+      "name": "knowledge_dependencies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kc_id": {
+          "name": "source_kc_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kc_id": {
+          "name": "target_kc_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship_type": {
+          "name": "relationship_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prerequisite'"
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_transitive": {
+          "name": "is_transitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source_material_id": {
+          "name": "source_material_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kd_project_source_target_rel": {
+          "name": "idx_kd_project_source_target_rel",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_kc_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_kc_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relationship_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kd_project_target": {
+          "name": "idx_kd_project_target",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_kc_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kd_project_source": {
+          "name": "idx_kd_project_source",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_kc_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "knowledge_dependencies_project_id_projects_id_fk": {
+          "name": "knowledge_dependencies_project_id_projects_id_fk",
+          "tableFrom": "knowledge_dependencies",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_dependencies_source_kc_id_knowledge_components_id_fk": {
+          "name": "knowledge_dependencies_source_kc_id_knowledge_components_id_fk",
+          "tableFrom": "knowledge_dependencies",
+          "tableTo": "knowledge_components",
+          "columnsFrom": ["source_kc_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_dependencies_target_kc_id_knowledge_components_id_fk": {
+          "name": "knowledge_dependencies_target_kc_id_knowledge_components_id_fk",
+          "tableFrom": "knowledge_dependencies",
+          "tableTo": "knowledge_components",
+          "columnsFrom": ["target_kc_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_dependencies_source_material_id_materials_id_fk": {
+          "name": "knowledge_dependencies_source_material_id_materials_id_fk",
+          "tableFrom": "knowledge_dependencies",
+          "tableTo": "materials",
+          "columnsFrom": ["source_material_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.material_chunks": {
+      "name": "material_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "material_chunks_material_id_idx": {
+          "name": "material_chunks_material_id_idx",
+          "columns": [
+            {
+              "expression": "material_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "material_chunks_project_id_idx": {
+          "name": "material_chunks_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "material_chunks_project_id_chunk_idx": {
+          "name": "material_chunks_project_id_chunk_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chunk_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "material_chunks_embedding_hnsw_idx": {
+          "name": "material_chunks_embedding_hnsw_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "material_chunks_material_id_materials_id_fk": {
+          "name": "material_chunks_material_id_materials_id_fk",
+          "tableFrom": "material_chunks",
+          "tableTo": "materials",
+          "columnsFrom": ["material_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "material_chunks_project_id_projects_id_fk": {
+          "name": "material_chunks_project_id_projects_id_fk",
+          "tableFrom": "material_chunks",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "material_chunks_user_id_users_id_fk": {
+          "name": "material_chunks_user_id_users_id_fk",
+          "tableFrom": "material_chunks",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.materials": {
+      "name": "materials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "materials_project_id_idx": {
+          "name": "materials_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "materials_user_id_idx": {
+          "name": "materials_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "materials_project_id_created_at_idx": {
+          "name": "materials_project_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "materials_project_id_projects_id_fk": {
+          "name": "materials_project_id_projects_id_fk",
+          "tableFrom": "materials",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "materials_user_id_users_id_fk": {
+          "name": "materials_user_id_users_id_fk",
+          "tableFrom": "materials",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.users": {
+      "name": "users",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_id_users_id_fk": {
+          "name": "profiles_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_user_id_name_lower_idx": {
+          "name": "projects_user_id_name_lower_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_user_id_users_id_fk": {
+          "name": "projects_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/0006_snapshot.json
+++ b/lib/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,1188 @@
+{
+  "id": "c78aedb4-a821-4789-bb8d-b6d70b3d4d76",
+  "prevId": "e9d1b9d5-3ceb-434f-b4db-2cf5db8eaf33",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chats_user_id_users_id_fk": {
+          "name": "chats_user_id_users_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chats_project_id_projects_id_fk": {
+          "name": "chats_project_id_projects_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": ["chat_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exercises": {
+      "name": "exercises",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kc_id": {
+          "name": "kc_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_number": {
+          "name": "page_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "solution": {
+          "name": "solution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_type": {
+          "name": "question_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_exercises_project": {
+          "name": "idx_exercises_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_exercises_material": {
+          "name": "idx_exercises_material",
+          "columns": [
+            {
+              "expression": "material_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_exercises_kc": {
+          "name": "idx_exercises_kc",
+          "columns": [
+            {
+              "expression": "kc_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exercises_project_id_projects_id_fk": {
+          "name": "exercises_project_id_projects_id_fk",
+          "tableFrom": "exercises",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exercises_user_id_users_id_fk": {
+          "name": "exercises_user_id_users_id_fk",
+          "tableFrom": "exercises",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exercises_material_id_materials_id_fk": {
+          "name": "exercises_material_id_materials_id_fk",
+          "tableFrom": "exercises",
+          "tableTo": "materials",
+          "columnsFrom": ["material_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "exercises_kc_id_knowledge_components_id_fk": {
+          "name": "exercises_kc_id_knowledge_components_id_fk",
+          "tableFrom": "exercises",
+          "tableTo": "knowledge_components",
+          "columnsFrom": ["kc_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.knowledge_components": {
+      "name": "knowledge_components",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pacer_category": {
+          "name": "pacer_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bloom_level": {
+          "name": "bloom_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_material_id": {
+          "name": "source_material_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kc_project_slug": {
+          "name": "idx_kc_project_slug",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kc_project_id": {
+          "name": "idx_kc_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "knowledge_components_project_id_projects_id_fk": {
+          "name": "knowledge_components_project_id_projects_id_fk",
+          "tableFrom": "knowledge_components",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_components_user_id_users_id_fk": {
+          "name": "knowledge_components_user_id_users_id_fk",
+          "tableFrom": "knowledge_components",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_components_source_material_id_materials_id_fk": {
+          "name": "knowledge_components_source_material_id_materials_id_fk",
+          "tableFrom": "knowledge_components",
+          "tableTo": "materials",
+          "columnsFrom": ["source_material_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.knowledge_dependencies": {
+      "name": "knowledge_dependencies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kc_id": {
+          "name": "source_kc_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kc_id": {
+          "name": "target_kc_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship_type": {
+          "name": "relationship_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prerequisite'"
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_transitive": {
+          "name": "is_transitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source_material_id": {
+          "name": "source_material_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kd_project_source_target_rel": {
+          "name": "idx_kd_project_source_target_rel",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_kc_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_kc_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relationship_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kd_project_target": {
+          "name": "idx_kd_project_target",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_kc_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kd_project_source": {
+          "name": "idx_kd_project_source",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_kc_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "knowledge_dependencies_project_id_projects_id_fk": {
+          "name": "knowledge_dependencies_project_id_projects_id_fk",
+          "tableFrom": "knowledge_dependencies",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_dependencies_source_kc_id_knowledge_components_id_fk": {
+          "name": "knowledge_dependencies_source_kc_id_knowledge_components_id_fk",
+          "tableFrom": "knowledge_dependencies",
+          "tableTo": "knowledge_components",
+          "columnsFrom": ["source_kc_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_dependencies_target_kc_id_knowledge_components_id_fk": {
+          "name": "knowledge_dependencies_target_kc_id_knowledge_components_id_fk",
+          "tableFrom": "knowledge_dependencies",
+          "tableTo": "knowledge_components",
+          "columnsFrom": ["target_kc_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_dependencies_source_material_id_materials_id_fk": {
+          "name": "knowledge_dependencies_source_material_id_materials_id_fk",
+          "tableFrom": "knowledge_dependencies",
+          "tableTo": "materials",
+          "columnsFrom": ["source_material_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.material_chunks": {
+      "name": "material_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "material_chunks_material_id_idx": {
+          "name": "material_chunks_material_id_idx",
+          "columns": [
+            {
+              "expression": "material_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "material_chunks_project_id_idx": {
+          "name": "material_chunks_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "material_chunks_project_id_chunk_idx": {
+          "name": "material_chunks_project_id_chunk_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chunk_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "material_chunks_embedding_hnsw_idx": {
+          "name": "material_chunks_embedding_hnsw_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "material_chunks_material_id_materials_id_fk": {
+          "name": "material_chunks_material_id_materials_id_fk",
+          "tableFrom": "material_chunks",
+          "tableTo": "materials",
+          "columnsFrom": ["material_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "material_chunks_project_id_projects_id_fk": {
+          "name": "material_chunks_project_id_projects_id_fk",
+          "tableFrom": "material_chunks",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "material_chunks_user_id_users_id_fk": {
+          "name": "material_chunks_user_id_users_id_fk",
+          "tableFrom": "material_chunks",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.materials": {
+      "name": "materials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "materials_project_id_idx": {
+          "name": "materials_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "materials_user_id_idx": {
+          "name": "materials_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "materials_project_id_created_at_idx": {
+          "name": "materials_project_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "materials_project_id_projects_id_fk": {
+          "name": "materials_project_id_projects_id_fk",
+          "tableFrom": "materials",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "materials_user_id_users_id_fk": {
+          "name": "materials_user_id_users_id_fk",
+          "tableFrom": "materials",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.users": {
+      "name": "users",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_id_users_id_fk": {
+          "name": "profiles_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_user_id_name_lower_idx": {
+          "name": "projects_user_id_name_lower_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_user_id_users_id_fk": {
+          "name": "projects_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1787502448813,
       "tag": "0004_dusty_dragon_lord",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1788776692106,
+      "tag": "0005_first_firestar",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1788776692106,
       "tag": "0005_first_firestar",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1788777673736,
+      "tag": "0006_mushy_the_hood",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/queries/knowledge-cycle.test.ts
+++ b/lib/db/queries/knowledge-cycle.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getPrerequisiteChain } from './knowledge';
+
+type DependencyEdge = {
+  sourceKcId: string;
+  targetKcId: string;
+  projectId: string;
+  relationshipType: string;
+  reasoning?: string;
+};
+
+type KnowledgeComponentNode = {
+  id: string;
+  projectId: string;
+  name: string;
+  orderIndex: number;
+};
+
+const mockDbSelect = vi.fn();
+const mockDbExecute = vi.fn();
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: (...args: unknown[]) => mockDbSelect(...args),
+    execute: (...args: unknown[]) => mockDbExecute(...args),
+  },
+}));
+
+function extractChunkText(c: unknown): string {
+  if (typeof c === 'string') return c;
+  if (!c || typeof c !== 'object') return '';
+  if ('value' in c) {
+    const val = (c as { value: unknown }).value;
+    return Array.isArray(val) ? val.join(' ') : String(val);
+  }
+  if ('name' in c) {
+    return String((c as { name: unknown }).name);
+  }
+  return '';
+}
+
+function getSqlString(sqlObj: { queryChunks?: unknown[] }): string {
+  return sqlObj.queryChunks?.map(extractChunkText).join(' ') ?? '';
+}
+
+/**
+ * Pure simulation of the exact SQL recursive CTE query logic executed by getPrerequisiteChain:
+ *
+ * WITH RECURSIVE prereq_tree AS (
+ *   SELECT kd.source_kc_id AS kc_id, kd.target_kc_id AS dependent_kc_id, 1 AS depth,
+ *          ARRAY[kd.target_kc_id::text, kd.source_kc_id::text] AS visited_path ...
+ *   WHERE kd.project_id = ${projectId} AND kd.target_kc_id = ${startKcId}
+ *   UNION ALL
+ *   SELECT kd.source_kc_id AS kc_id, kd.target_kc_id AS dependent_kc_id, prev.depth + 1 AS depth,
+ *          prev.visited_path || kd.source_kc_id::text AS visited_path ...
+ *   JOIN prereq_tree prev ON kd.target_kc_id = prev.kc_id
+ *   WHERE kd.project_id = ${projectId} AND prev.depth < ${maxDepth}
+ *     AND NOT (kd.source_kc_id::text = ANY(prev.visited_path))
+ * )
+ * SELECT DISTINCT ON (pt.kc_id) ... ORDER BY depth ASC, orderIndex ASC, name ASC;
+ */
+function simulatePrerequisiteCTE({
+  dependencies,
+  concepts,
+  projectId,
+  startKcId,
+  maxDepth = 10,
+}: {
+  dependencies: DependencyEdge[];
+  concepts: KnowledgeComponentNode[];
+  projectId: string;
+  startKcId: string;
+  maxDepth?: number;
+}) {
+  type CTERow = {
+    kcId: string;
+    dependentKcId: string;
+    depth: number;
+    visitedPath: string[];
+    relationshipType: string;
+    reasoning?: string;
+  };
+
+  const queue: CTERow[] = [];
+  const allGeneratedRows: CTERow[] = [];
+
+  const baseDependencies = dependencies.filter(
+    (d) => d.projectId === projectId && d.targetKcId === startKcId,
+  );
+
+  for (const dep of baseDependencies) {
+    const row: CTERow = {
+      kcId: dep.sourceKcId,
+      dependentKcId: dep.targetKcId,
+      depth: 1,
+      visitedPath: [dep.targetKcId, dep.sourceKcId],
+      relationshipType: dep.relationshipType,
+      reasoning: dep.reasoning,
+    };
+    queue.push(row);
+    allGeneratedRows.push(row);
+  }
+
+  while (queue.length > 0) {
+    const prev = queue.shift();
+    if (!prev) {
+      break;
+    }
+
+    if (prev.depth >= maxDepth) {
+      continue;
+    }
+
+    const nextDeps = dependencies.filter(
+      (d) =>
+        d.projectId === projectId &&
+        d.targetKcId === prev.kcId &&
+        !prev.visitedPath.includes(d.sourceKcId),
+    );
+
+    for (const dep of nextDeps) {
+      const nextRow: CTERow = {
+        kcId: dep.sourceKcId,
+        dependentKcId: dep.targetKcId,
+        depth: prev.depth + 1,
+        visitedPath: [...prev.visitedPath, dep.sourceKcId],
+        relationshipType: dep.relationshipType,
+        reasoning: dep.reasoning,
+      };
+      queue.push(nextRow);
+      allGeneratedRows.push(nextRow);
+    }
+  }
+
+  const conceptMap = new Map<string, KnowledgeComponentNode>(
+    concepts.filter((c) => c.projectId === projectId).map((c) => [c.id, c]),
+  );
+
+  const distinctByKcId = new Map<
+    string,
+    {
+      concept: KnowledgeComponentNode;
+      depth: number;
+      relationshipType: string;
+      reasoning?: string;
+    }
+  >();
+
+  for (const row of allGeneratedRows) {
+    const concept = conceptMap.get(row.kcId);
+    if (!concept) continue;
+
+    const existing = distinctByKcId.get(row.kcId);
+    if (!existing || row.depth < existing.depth) {
+      distinctByKcId.set(row.kcId, {
+        concept,
+        depth: row.depth,
+        relationshipType: row.relationshipType,
+        reasoning: row.reasoning,
+      });
+    }
+  }
+
+  return Array.from(distinctByKcId.values()).sort((a, b) => {
+    if (a.depth !== b.depth) return a.depth - b.depth;
+    if (a.concept.orderIndex !== b.concept.orderIndex) {
+      return a.concept.orderIndex - b.concept.orderIndex;
+    }
+    return a.concept.name.localeCompare(b.concept.name);
+  });
+}
+
+describe('Prerequisite Chain Cycle Guard & Topologies', () => {
+  const proj1 = 'project-1';
+  const proj2 = 'project-2';
+
+  const concepts: KnowledgeComponentNode[] = [
+    { id: 'A', projectId: proj1, name: 'Concept A', orderIndex: 1 },
+    { id: 'B', projectId: proj1, name: 'Concept B', orderIndex: 2 },
+    { id: 'C', projectId: proj1, name: 'Concept C', orderIndex: 3 },
+    { id: 'D', projectId: proj1, name: 'Concept D', orderIndex: 4 },
+    { id: 'Other_A', projectId: proj2, name: 'Other Concept A', orderIndex: 1 },
+  ];
+
+  it('terminates circular graph topology A -> B -> C -> A cleanly without infinite loop', () => {
+    const dependencies: DependencyEdge[] = [
+      { sourceKcId: 'A', targetKcId: 'B', projectId: proj1, relationshipType: 'prerequisite' },
+      { sourceKcId: 'B', targetKcId: 'C', projectId: proj1, relationshipType: 'prerequisite' },
+      { sourceKcId: 'C', targetKcId: 'A', projectId: proj1, relationshipType: 'prerequisite' },
+    ];
+
+    const result = simulatePrerequisiteCTE({
+      dependencies,
+      concepts,
+      projectId: proj1,
+      startKcId: 'C',
+      maxDepth: 10,
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ concept: { id: 'B' }, depth: 1 });
+    expect(result[1]).toMatchObject({ concept: { id: 'A' }, depth: 2 });
+  });
+
+  it('terminates mutually dependent co-requisite graph A <-> B cleanly', () => {
+    const dependencies: DependencyEdge[] = [
+      { sourceKcId: 'A', targetKcId: 'B', projectId: proj1, relationshipType: 'prerequisite' },
+      { sourceKcId: 'B', targetKcId: 'A', projectId: proj1, relationshipType: 'prerequisite' },
+    ];
+
+    const resultFromB = simulatePrerequisiteCTE({
+      dependencies,
+      concepts,
+      projectId: proj1,
+      startKcId: 'B',
+      maxDepth: 10,
+    });
+
+    expect(resultFromB).toHaveLength(1);
+    expect(resultFromB[0]).toMatchObject({ concept: { id: 'A' }, depth: 1 });
+  });
+
+  it('resolves diamond dependency graph and deduplicates at closest depth', () => {
+    const dependencies: DependencyEdge[] = [
+      { sourceKcId: 'B', targetKcId: 'D', projectId: proj1, relationshipType: 'prerequisite' },
+      { sourceKcId: 'C', targetKcId: 'D', projectId: proj1, relationshipType: 'prerequisite' },
+      { sourceKcId: 'A', targetKcId: 'B', projectId: proj1, relationshipType: 'prerequisite' },
+      { sourceKcId: 'A', targetKcId: 'C', projectId: proj1, relationshipType: 'prerequisite' },
+      { sourceKcId: 'A', targetKcId: 'D', projectId: proj1, relationshipType: 'prerequisite' },
+    ];
+
+    const result = simulatePrerequisiteCTE({
+      dependencies,
+      concepts,
+      projectId: proj1,
+      startKcId: 'D',
+      maxDepth: 10,
+    });
+
+    expect(result).toHaveLength(3);
+    const nodeIds = result.map((r) => r.concept.id);
+    expect(nodeIds).toContain('A');
+    expect(nodeIds).toContain('B');
+    expect(nodeIds).toContain('C');
+    expect(result.every((r) => r.depth === 1)).toBe(true);
+  });
+
+  it('strictly enforces tenant isolation across projects', () => {
+    const dependencies: DependencyEdge[] = [
+      { sourceKcId: 'A', targetKcId: 'B', projectId: proj1, relationshipType: 'prerequisite' },
+      {
+        sourceKcId: 'Other_A',
+        targetKcId: 'B',
+        projectId: proj2,
+        relationshipType: 'prerequisite',
+      },
+    ];
+
+    const result = simulatePrerequisiteCTE({
+      dependencies,
+      concepts,
+      projectId: proj1,
+      startKcId: 'B',
+      maxDepth: 10,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].concept.id).toBe('A');
+    expect(result.some((r) => r.concept.id === 'Other_A')).toBe(false);
+  });
+
+  it('respects maxDepth boundary limit', () => {
+    const dependencies: DependencyEdge[] = [
+      { sourceKcId: 'C', targetKcId: 'D', projectId: proj1, relationshipType: 'prerequisite' },
+      { sourceKcId: 'B', targetKcId: 'C', projectId: proj1, relationshipType: 'prerequisite' },
+      { sourceKcId: 'A', targetKcId: 'B', projectId: proj1, relationshipType: 'prerequisite' },
+    ];
+
+    const result = simulatePrerequisiteCTE({
+      dependencies,
+      concepts,
+      projectId: proj1,
+      startKcId: 'D',
+      maxDepth: 2,
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].concept.id).toBe('C');
+    expect(result[1].concept.id).toBe('B');
+  });
+
+  it('exercises getPrerequisiteChain directly and confirms cycle-guarded SQL generation', async () => {
+    const mockLimit = vi.fn().mockResolvedValueOnce([{ id: 'c-1' }]);
+    mockDbSelect.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: mockLimit }) }),
+    });
+
+    const mockRows = [
+      { id: 'p-1', name: 'Prereq 1', depth: 1, orderIndex: 1 },
+      { id: 'p-2', name: 'Prereq 2', depth: 2, orderIndex: 2 },
+    ];
+    mockDbExecute.mockResolvedValueOnce(mockRows);
+
+    const chain = await getPrerequisiteChain({
+      projectId: 'proj-1',
+      kcId: 'Concept Name',
+      maxDepth: 10,
+    });
+
+    expect(chain).toEqual(mockRows);
+    expect(mockDbExecute).toHaveBeenCalledTimes(1);
+
+    const executedSql = mockDbExecute.mock.calls[0][0];
+    const sqlText = getSqlString(executedSql);
+    expect(sqlText).toContain('WITH RECURSIVE prereq_tree');
+    expect(sqlText).toContain('NOT (kd.source_kc_id::text = ANY(prev.visited_path))');
+  });
+});

--- a/lib/db/queries/knowledge-frontier.test.ts
+++ b/lib/db/queries/knowledge-frontier.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getReadyToLearnFrontier } from './knowledge';
+
+type DependencyEdge = {
+  sourceKcId: string;
+  targetKcId: string;
+  projectId: string;
+  relationshipType: string;
+};
+
+type KnowledgeComponentNode = {
+  id: string;
+  projectId: string;
+  name: string;
+  status: 'active' | 'archived' | 'draft';
+  orderIndex: number;
+};
+
+const mockDbExecute = vi.fn();
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    execute: (...args: unknown[]) => mockDbExecute(...args),
+  },
+}));
+
+function extractChunkText(c: unknown): string {
+  if (typeof c === 'string') return c;
+  if (!c || typeof c !== 'object') return '';
+  if ('queryChunks' in c && Array.isArray((c as { queryChunks: unknown[] }).queryChunks)) {
+    return (c as { queryChunks: unknown[] }).queryChunks.map(extractChunkText).join(' ');
+  }
+  if ('value' in c) {
+    const val = (c as { value: unknown }).value;
+    return Array.isArray(val) ? val.join(' ') : String(val);
+  }
+  if ('name' in c) {
+    return String((c as { name: unknown }).name);
+  }
+  return '';
+}
+
+function getSqlString(sqlObj: { queryChunks?: unknown[] }): string {
+  return sqlObj.queryChunks?.map(extractChunkText).join(' ') ?? '';
+}
+
+/**
+ * Pure simulation of the exact SQL logic executed by getReadyToLearnFrontier:
+ *
+ * WITH unmastered_prereqs AS (
+ *   SELECT kd.target_kc_id
+ *   FROM knowledge_dependencies kd
+ *   WHERE kd.project_id = ${projectId}
+ *     AND kd.relationship_type = 'prerequisite'
+ *     AND NOT (kd.source_kc_id = ANY(masteredKcIds))
+ * )
+ * SELECT kc.*
+ * FROM knowledge_components kc
+ * WHERE kc.project_id = ${projectId}
+ *   AND kc.status = 'active'
+ *   AND NOT (kc.id = ANY(masteredKcIds))
+ *   AND NOT EXISTS (
+ *     SELECT 1 FROM unmastered_prereqs up WHERE up.target_kc_id = kc.id
+ *   )
+ * ORDER BY kc.order_index ASC, kc.name ASC;
+ */
+function simulateFrontierQuery({
+  dependencies,
+  concepts,
+  projectId,
+  masteredKcIds = [],
+}: {
+  dependencies: DependencyEdge[];
+  concepts: KnowledgeComponentNode[];
+  projectId: string;
+  masteredKcIds?: string[];
+}): KnowledgeComponentNode[] {
+  const masteredSet = new Set(masteredKcIds);
+
+  // 1. Unmastered prerequisites for target KCs in the project
+  const unmasteredPrereqsTargetSet = new Set<string>();
+  for (const dep of dependencies) {
+    if (
+      dep.projectId === projectId &&
+      dep.relationshipType === 'prerequisite' &&
+      !masteredSet.has(dep.sourceKcId)
+    ) {
+      unmasteredPrereqsTargetSet.add(dep.targetKcId);
+    }
+  }
+
+  // 2. Concepts in the project that are active, not yet mastered, and have no unmastered prerequisites
+  return concepts
+    .filter(
+      (kc) =>
+        kc.projectId === projectId &&
+        kc.status === 'active' &&
+        !masteredSet.has(kc.id) &&
+        !unmasteredPrereqsTargetSet.has(kc.id),
+    )
+    .sort((a, b) => {
+      if (a.orderIndex !== b.orderIndex) return a.orderIndex - b.orderIndex;
+      return a.name.localeCompare(b.name);
+    });
+}
+
+describe('Ready-to-Learn Frontier Topologies & Logic', () => {
+  const proj1 = 'proj-1';
+  const proj2 = 'proj-2';
+
+  const concepts: KnowledgeComponentNode[] = [
+    { id: 'A', projectId: proj1, name: 'Concept A (Root)', status: 'active', orderIndex: 1 },
+    { id: 'B', projectId: proj1, name: 'Concept B', status: 'active', orderIndex: 2 },
+    { id: 'C', projectId: proj1, name: 'Concept C', status: 'active', orderIndex: 3 },
+    { id: 'D', projectId: proj1, name: 'Concept D', status: 'active', orderIndex: 4 },
+    { id: 'E', projectId: proj1, name: 'Concept E (Root 2)', status: 'active', orderIndex: 5 },
+    {
+      id: 'Inactive',
+      projectId: proj1,
+      name: 'Inactive Concept',
+      status: 'archived',
+      orderIndex: 6,
+    },
+    { id: 'Proj2_A', projectId: proj2, name: 'Project 2 Concept', status: 'active', orderIndex: 1 },
+  ];
+
+  it('resolves all root foundational concepts when masteredKcIds is empty', () => {
+    // Topology: A -> B -> C; E -> D
+    const dependencies: DependencyEdge[] = [
+      { sourceKcId: 'A', targetKcId: 'B', projectId: proj1, relationshipType: 'prerequisite' },
+      { sourceKcId: 'B', targetKcId: 'C', projectId: proj1, relationshipType: 'prerequisite' },
+      { sourceKcId: 'E', targetKcId: 'D', projectId: proj1, relationshipType: 'prerequisite' },
+    ];
+
+    const frontier = simulateFrontierQuery({
+      dependencies,
+      concepts,
+      projectId: proj1,
+      masteredKcIds: [],
+    });
+
+    const frontierIds = frontier.map((c) => c.id);
+    expect(frontierIds).toEqual(['A', 'E']);
+  });
+
+  it('unblocks progression as prerequisite concepts are added to masteredKcIds', () => {
+    // Topology: A -> B -> C
+    const dependencies: DependencyEdge[] = [
+      { sourceKcId: 'A', targetKcId: 'B', projectId: proj1, relationshipType: 'prerequisite' },
+      { sourceKcId: 'B', targetKcId: 'C', projectId: proj1, relationshipType: 'prerequisite' },
+    ];
+
+    // Step 1: Nothing mastered -> Frontier is A and E
+    const f0 = simulateFrontierQuery({
+      dependencies,
+      concepts,
+      projectId: proj1,
+      masteredKcIds: [],
+    });
+    expect(f0.map((c) => c.id)).toContain('A');
+
+    // Step 2: Mastered A -> A is removed, B is unblocked into frontier
+    const f1 = simulateFrontierQuery({
+      dependencies,
+      concepts,
+      projectId: proj1,
+      masteredKcIds: ['A'],
+    });
+    const f1Ids = f1.map((c) => c.id);
+    expect(f1Ids).toContain('B');
+    expect(f1Ids).not.toContain('A');
+    expect(f1Ids).not.toContain('C'); // C still blocked on B
+
+    // Step 3: Mastered A and B -> B is removed, C is unblocked into frontier
+    const f2 = simulateFrontierQuery({
+      dependencies,
+      concepts,
+      projectId: proj1,
+      masteredKcIds: ['A', 'B'],
+    });
+    const f2Ids = f2.map((c) => c.id);
+    expect(f2Ids).toContain('C');
+    expect(f2Ids).not.toContain('A');
+    expect(f2Ids).not.toContain('B');
+  });
+
+  it('handles multi-prerequisite diamond graphs (AND gate dependencies)', () => {
+    // Topology: A is root; B and C require A; D requires BOTH B and C
+    const dependencies: DependencyEdge[] = [
+      { sourceKcId: 'A', targetKcId: 'B', projectId: proj1, relationshipType: 'prerequisite' },
+      { sourceKcId: 'A', targetKcId: 'C', projectId: proj1, relationshipType: 'prerequisite' },
+      { sourceKcId: 'B', targetKcId: 'D', projectId: proj1, relationshipType: 'prerequisite' },
+      { sourceKcId: 'C', targetKcId: 'D', projectId: proj1, relationshipType: 'prerequisite' },
+    ];
+
+    // Mastered A -> B and C should be on frontier, but D should NOT yet be ready
+    const fA = simulateFrontierQuery({
+      dependencies,
+      concepts,
+      projectId: proj1,
+      masteredKcIds: ['A'],
+    });
+    expect(fA.map((c) => c.id)).toContain('B');
+    expect(fA.map((c) => c.id)).toContain('C');
+    expect(fA.map((c) => c.id)).not.toContain('D');
+
+    // Mastered A and only B -> D still blocked because C is not mastered
+    const fAB = simulateFrontierQuery({
+      dependencies,
+      concepts,
+      projectId: proj1,
+      masteredKcIds: ['A', 'B'],
+    });
+    expect(fAB.map((c) => c.id)).toContain('C');
+    expect(fAB.map((c) => c.id)).not.toContain('D');
+
+    // Mastered A, B, and C -> D is finally unblocked!
+    const fABC = simulateFrontierQuery({
+      dependencies,
+      concepts,
+      projectId: proj1,
+      masteredKcIds: ['A', 'B', 'C'],
+    });
+    expect(fABC.map((c) => c.id)).toContain('D');
+    expect(fABC.map((c) => c.id)).not.toContain('B');
+    expect(fABC.map((c) => c.id)).not.toContain('C');
+  });
+
+  it('strictly isolates tenant projects', () => {
+    const dependencies: DependencyEdge[] = [
+      {
+        sourceKcId: 'Proj2_A',
+        targetKcId: 'A',
+        projectId: proj2,
+        relationshipType: 'prerequisite',
+      },
+    ];
+
+    // Even if proj2 has a dependency, proj1 query does not see it and does not include Proj2_A
+    const frontier = simulateFrontierQuery({
+      dependencies,
+      concepts,
+      projectId: proj1,
+      masteredKcIds: [],
+    });
+
+    const ids = frontier.map((c) => c.id);
+    expect(ids).toContain('A');
+    expect(ids).not.toContain('Proj2_A');
+  });
+
+  it('excludes non-active concepts regardless of prerequisite status', () => {
+    const dependencies: DependencyEdge[] = [];
+
+    const frontier = simulateFrontierQuery({
+      dependencies,
+      concepts,
+      projectId: proj1,
+      masteredKcIds: [],
+    });
+
+    expect(frontier.map((c) => c.id)).not.toContain('Inactive');
+  });
+
+  it('verifies generated SQL of getReadyToLearnFrontier for structure and tenant constraints', async () => {
+    mockDbExecute.mockResolvedValueOnce([]);
+
+    await getReadyToLearnFrontier({
+      projectId: 'project-xyz',
+      masteredKcIds: [
+        '11111111-1111-1111-1111-111111111111',
+        '22222222-2222-2222-2222-222222222222',
+      ],
+    });
+
+    expect(mockDbExecute).toHaveBeenCalledTimes(1);
+    const sqlText = getSqlString(mockDbExecute.mock.calls[0][0]);
+
+    expect(sqlText).toContain('project-xyz');
+    expect(sqlText).toContain('active');
+    expect(sqlText).toContain('WITH unmastered_prereqs AS');
+    expect(sqlText).toContain('NOT EXISTS');
+  });
+});

--- a/lib/db/queries/knowledge.test.ts
+++ b/lib/db/queries/knowledge.test.ts
@@ -2,8 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   cleanupMaterialExtractedGraph,
   getActiveProjectConceptNames,
+  getGraphNeighborhood,
   getKnowledgeComponentsByProjectId,
   getKnowledgeDependenciesByProjectId,
+  getPrerequisiteChain,
   insertExercises,
   insertKnowledgeDependencies,
   upsertKnowledgeComponents,
@@ -13,6 +15,7 @@ const mockDbInsert = vi.fn();
 const mockDbSelect = vi.fn();
 const mockDbDelete = vi.fn();
 const mockDbTransaction = vi.fn();
+const mockDbExecute = vi.fn();
 
 vi.mock('@/lib/db', () => ({
   db: {
@@ -20,6 +23,7 @@ vi.mock('@/lib/db', () => ({
     select: (...args: unknown[]) => mockDbSelect(...args),
     delete: (...args: unknown[]) => mockDbDelete(...args),
     transaction: (...args: unknown[]) => mockDbTransaction(...args),
+    execute: (...args: unknown[]) => mockDbExecute(...args),
   },
 }));
 
@@ -303,6 +307,314 @@ describe('Knowledge Graph DB Queries', () => {
 
       expect(mockDbTransaction).toHaveBeenCalledTimes(1);
       expect(mockTxDelete).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('getGraphNeighborhood', () => {
+    it('returns null concept and empty lists when concept does not exist in project', async () => {
+      const mockLimit = vi.fn().mockResolvedValueOnce([]);
+      const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+      const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+      mockDbSelect.mockReturnValue({ from: mockFrom });
+
+      const result = await getGraphNeighborhood('proj-1', '550e8400-e29b-41d4-a716-446655440000');
+
+      expect(result).toEqual({
+        concept: null,
+        prerequisites: [],
+        unlocked: [],
+        depth: 1,
+      });
+    });
+
+    it('retrieves 1-hop prerequisites and unlocked concepts with tenant isolation', async () => {
+      const centralConcept = {
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        projectId: 'proj-1',
+        slug: 'binary-search',
+        name: 'Binary Search',
+        pacerCategory: 'procedural',
+        bloomLevel: 3,
+        aliases: [],
+      };
+      const prereqConcept = {
+        id: '11111111-1111-1111-1111-111111111111',
+        projectId: 'proj-1',
+        slug: 'sorted-arrays',
+        name: 'Sorted Arrays',
+        pacerCategory: 'conceptual',
+        bloomLevel: 2,
+        aliases: [],
+      };
+      const unlockedConcept = {
+        id: '22222222-2222-2222-2222-222222222222',
+        projectId: 'proj-1',
+        slug: 'binary-search-tree',
+        name: 'Binary Search Tree',
+        pacerCategory: 'conceptual',
+        bloomLevel: 3,
+        aliases: [],
+      };
+
+      // 1st select: find target concept
+      const mockLimit = vi.fn().mockResolvedValueOnce([centralConcept]);
+      const mockWhereTarget = vi.fn().mockReturnValue({ limit: mockLimit });
+      const mockFromTarget = vi.fn().mockReturnValue({ where: mockWhereTarget });
+
+      // 2nd select: prerequisites (targetKcId = centralConcept.id)
+      const mockWherePrereqs = vi.fn().mockResolvedValueOnce([
+        {
+          concept: prereqConcept,
+          dependency: {
+            relationshipType: 'prerequisite',
+            reasoning: 'Need sorted data',
+          },
+        },
+      ]);
+      const mockInnerJoinPrereqs = vi.fn().mockReturnValue({ where: mockWherePrereqs });
+      const mockFromPrereqs = vi.fn().mockReturnValue({ innerJoin: mockInnerJoinPrereqs });
+
+      // 3rd select: unlocked (sourceKcId = centralConcept.id)
+      const mockWhereUnlocked = vi.fn().mockResolvedValueOnce([
+        {
+          concept: unlockedConcept,
+          dependency: {
+            relationshipType: 'prerequisite',
+            reasoning: 'BST builds on binary search principles',
+          },
+        },
+      ]);
+      const mockInnerJoinUnlocked = vi.fn().mockReturnValue({ where: mockWhereUnlocked });
+      const mockFromUnlocked = vi.fn().mockReturnValue({ innerJoin: mockInnerJoinUnlocked });
+
+      mockDbSelect
+        .mockReturnValueOnce({ from: mockFromTarget })
+        .mockReturnValueOnce({ from: mockFromPrereqs })
+        .mockReturnValueOnce({ from: mockFromUnlocked });
+
+      const result = await getGraphNeighborhood('proj-1', centralConcept.id, 1);
+
+      expect(result.concept).toEqual(centralConcept);
+      expect(result.depth).toBe(1);
+      expect(result.prerequisites).toEqual([
+        {
+          ...prereqConcept,
+          depth: 1,
+          relationshipType: 'prerequisite',
+          reasoning: 'Need sorted data',
+        },
+      ]);
+      expect(result.unlocked).toEqual([
+        {
+          ...unlockedConcept,
+          depth: 1,
+          relationshipType: 'prerequisite',
+          reasoning: 'BST builds on binary search principles',
+        },
+      ]);
+    });
+
+    it('expands to 2-hop neighbors recursively when depth = 2 and deduplicates visited nodes', async () => {
+      const centralConcept = {
+        id: 'c-0',
+        projectId: 'proj-1',
+        slug: 'c-0',
+        name: 'Concept 0',
+      };
+      const hop1Prereq = {
+        id: 'p-1',
+        projectId: 'proj-1',
+        slug: 'p-1',
+        name: 'Hop 1 Prereq',
+      };
+      const hop2Prereq = {
+        id: 'p-2',
+        projectId: 'proj-1',
+        slug: 'p-2',
+        name: 'Hop 2 Prereq',
+      };
+      const hop1Unlocked = {
+        id: 'u-1',
+        projectId: 'proj-1',
+        slug: 'u-1',
+        name: 'Hop 1 Unlocked',
+      };
+      const hop2Unlocked = {
+        id: 'u-2',
+        projectId: 'proj-1',
+        slug: 'u-2',
+        name: 'Hop 2 Unlocked',
+      };
+
+      // 1. Concept lookup
+      const mockLimit = vi.fn().mockResolvedValueOnce([centralConcept]);
+      mockDbSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: mockLimit }) }),
+      });
+
+      // 2. 1-hop prereqs
+      mockDbSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValueOnce([
+              {
+                concept: hop1Prereq,
+                dependency: { relationshipType: 'prerequisite', reasoning: 'p1 reason' },
+              },
+            ]),
+          }),
+        }),
+      });
+
+      // 3. 1-hop unlocked
+      mockDbSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValueOnce([
+              {
+                concept: hop1Unlocked,
+                dependency: { relationshipType: 'prerequisite', reasoning: 'u1 reason' },
+              },
+            ]),
+          }),
+        }),
+      });
+
+      // 4. 2-hop prereqs (targetKcId in [p-1])
+      mockDbSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValueOnce([
+              {
+                concept: hop2Prereq,
+                dependency: { relationshipType: 'prerequisite', reasoning: 'p2 reason' },
+              },
+            ]),
+          }),
+        }),
+      });
+
+      // 5. 2-hop unlocked (sourceKcId in [u-1])
+      mockDbSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValueOnce([
+              {
+                concept: hop2Unlocked,
+                dependency: { relationshipType: 'prerequisite', reasoning: 'u2 reason' },
+              },
+            ]),
+          }),
+        }),
+      });
+
+      const result = await getGraphNeighborhood({
+        projectId: 'proj-1',
+        kcId: 'c-0',
+        depth: 2,
+      });
+
+      expect(result.depth).toBe(2);
+      expect(result.prerequisites).toHaveLength(2);
+      expect(result.prerequisites[0]).toMatchObject({ id: 'p-1', depth: 1 });
+      expect(result.prerequisites[1]).toMatchObject({ id: 'p-2', depth: 2 });
+      expect(result.unlocked).toHaveLength(2);
+      expect(result.unlocked[0]).toMatchObject({ id: 'u-1', depth: 1 });
+      expect(result.unlocked[1]).toMatchObject({ id: 'u-2', depth: 2 });
+    });
+  });
+
+  describe('getPrerequisiteChain', () => {
+    it('returns empty array when concept does not exist in project', async () => {
+      const mockLimit = vi.fn().mockResolvedValueOnce([]);
+      mockDbSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: mockLimit }) }),
+      });
+
+      const result = await getPrerequisiteChain('proj-1', 'non-existent');
+      expect(result).toEqual([]);
+      expect(mockDbExecute).not.toHaveBeenCalled();
+    });
+
+    it('executes recursive CTE query with cycle guard and returns ordered ancestors', async () => {
+      const targetConcept = {
+        id: '33333333-3333-3333-3333-333333333333',
+        projectId: 'proj-1',
+        slug: 'dijkstra',
+      };
+
+      const mockLimit = vi.fn().mockResolvedValueOnce([targetConcept]);
+      mockDbSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: mockLimit }) }),
+      });
+
+      const ancestorRows = [
+        {
+          id: '22222222-2222-2222-2222-222222222222',
+          projectId: 'proj-1',
+          slug: 'bfs',
+          name: 'Breadth-First Search',
+          pacerCategory: 'procedural',
+          bloomLevel: 3,
+          aliases: [],
+          status: 'active',
+          orderIndex: 2,
+          depth: 1,
+          relationshipType: 'prerequisite',
+          reasoning: 'Graph traversal foundation',
+        },
+        {
+          id: '11111111-1111-1111-1111-111111111111',
+          projectId: 'proj-1',
+          slug: 'graphs',
+          name: 'Graphs',
+          pacerCategory: 'conceptual',
+          bloomLevel: 2,
+          aliases: [],
+          status: 'active',
+          orderIndex: 1,
+          depth: 2,
+          relationshipType: 'prerequisite',
+          reasoning: 'Core graph representation',
+        },
+      ];
+
+      mockDbExecute.mockResolvedValueOnce(ancestorRows);
+
+      const chain = await getPrerequisiteChain('proj-1', targetConcept.id, 10);
+
+      expect(chain).toEqual(ancestorRows);
+      expect(mockDbExecute).toHaveBeenCalledTimes(1);
+
+      // Verify that the SQL query includes recursive CTE and cycle guard
+      const executedSql = mockDbExecute.mock.calls[0][0];
+      const sqlString = getSqlString(executedSql);
+      expect(sqlString.toLowerCase()).toContain('recursive');
+      expect(sqlString.toLowerCase()).toContain('visited_path');
+      expect(sqlString).toContain('ANY');
+    });
+
+    it('supports object options signature { projectId, kcId, maxDepth }', async () => {
+      const targetConcept = {
+        id: '33333333-3333-3333-3333-333333333333',
+        projectId: 'proj-1',
+      };
+
+      const mockLimit = vi.fn().mockResolvedValueOnce([targetConcept]);
+      mockDbSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: mockLimit }) }),
+      });
+
+      mockDbExecute.mockResolvedValueOnce([]);
+
+      const chain = await getPrerequisiteChain({
+        projectId: 'proj-1',
+        kcId: targetConcept.id,
+        maxDepth: 5,
+      });
+
+      expect(chain).toEqual([]);
+      expect(mockDbExecute).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/lib/db/queries/knowledge.test.ts
+++ b/lib/db/queries/knowledge.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getKnowledgeComponentsByProjectId,
   getKnowledgeDependenciesByProjectId,
+  insertExercises,
   insertKnowledgeDependencies,
   upsertKnowledgeComponents,
 } from './knowledge';
@@ -134,6 +135,55 @@ describe('Knowledge Graph DB Queries', () => {
       expect(mockDbSelect).toHaveBeenCalledTimes(1);
       expect(mockWhere).toHaveBeenCalledTimes(1);
       expect(result).toEqual([{ id: 'kd-1', relationshipType: 'prerequisite' }]);
+    });
+  });
+
+  describe('insertExercises', () => {
+    it('returns empty array when input is empty', async () => {
+      const result = await insertExercises([]);
+      expect(result).toEqual([]);
+      expect(mockDbInsert).not.toHaveBeenCalled();
+    });
+
+    it('inserts exercises and returns created records', async () => {
+      const mockReturning = vi.fn().mockResolvedValueOnce([
+        {
+          id: 'ex-1',
+          projectId: 'proj-1',
+          userId: 'user-1',
+          materialId: 'mat-1',
+          kcId: 'kc-1',
+          pageNumber: 5,
+          title: 'Problem 1',
+          prompt: 'Solve 2x=4',
+          solution: 'x=2',
+          questionType: 'calculation',
+          difficulty: 2,
+        },
+      ]);
+      const mockValues = vi.fn().mockReturnValue({ returning: mockReturning });
+      mockDbInsert.mockReturnValue({ values: mockValues });
+
+      const result = await insertExercises([
+        {
+          projectId: 'proj-1',
+          userId: 'user-1',
+          materialId: 'mat-1',
+          kcId: 'kc-1',
+          pageNumber: 5,
+          title: 'Problem 1',
+          prompt: 'Solve 2x=4',
+          solution: 'x=2',
+          questionType: 'calculation',
+          difficulty: 2,
+        },
+      ]);
+
+      expect(mockDbInsert).toHaveBeenCalledTimes(1);
+      expect(mockValues).toHaveBeenCalledTimes(1);
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('ex-1');
+      expect(result[0].pageNumber).toBe(5);
     });
   });
 });

--- a/lib/db/queries/knowledge.test.ts
+++ b/lib/db/queries/knowledge.test.ts
@@ -2,10 +2,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   cleanupMaterialExtractedGraph,
   getActiveProjectConceptNames,
+  getExercisesForKc,
   getGraphNeighborhood,
   getKnowledgeComponentsByProjectId,
   getKnowledgeDependenciesByProjectId,
   getPrerequisiteChain,
+  getReadyToLearnFrontier,
   insertExercises,
   insertKnowledgeDependencies,
   upsertKnowledgeComponents,
@@ -30,6 +32,9 @@ vi.mock('@/lib/db', () => ({
 function extractChunkText(c: unknown): string {
   if (typeof c === 'string') return c;
   if (!c || typeof c !== 'object') return '';
+  if ('queryChunks' in c && Array.isArray((c as { queryChunks: unknown[] }).queryChunks)) {
+    return (c as { queryChunks: unknown[] }).queryChunks.map(extractChunkText).join(' ');
+  }
   if ('value' in c) {
     const val = (c as { value: unknown }).value;
     return Array.isArray(val) ? val.join(' ') : String(val);
@@ -615,6 +620,177 @@ describe('Knowledge Graph DB Queries', () => {
 
       expect(chain).toEqual([]);
       expect(mockDbExecute).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getReadyToLearnFrontier', () => {
+    it('returns empty array when projectId is empty', async () => {
+      const result = await getReadyToLearnFrontier('', []);
+      expect(result).toEqual([]);
+      expect(mockDbExecute).not.toHaveBeenCalled();
+    });
+
+    it('retrieves root foundational concepts with default masteredKcIds = []', async () => {
+      const rootConcepts = [
+        {
+          id: '11111111-1111-1111-1111-111111111111',
+          projectId: 'proj-1',
+          name: 'Arrays',
+          slug: 'arrays',
+          status: 'active',
+          orderIndex: 0,
+        },
+        {
+          id: '22222222-2222-2222-2222-222222222222',
+          projectId: 'proj-1',
+          name: 'Variables',
+          slug: 'variables',
+          status: 'active',
+          orderIndex: 1,
+        },
+      ];
+
+      mockDbExecute.mockResolvedValueOnce(rootConcepts);
+
+      const result = await getReadyToLearnFrontier('proj-1');
+
+      expect(result).toEqual(rootConcepts);
+      expect(mockDbExecute).toHaveBeenCalledTimes(1);
+
+      const executedSql = mockDbExecute.mock.calls[0][0];
+      const sqlString = getSqlString(executedSql);
+      expect(sqlString).toContain('status');
+      expect(sqlString).toContain('active');
+      expect(sqlString).toContain('NOT EXISTS');
+    });
+
+    it('unblocks concepts when prerequisite concepts are passed in masteredKcIds', async () => {
+      const masteredId = '11111111-1111-1111-1111-111111111111';
+      const unblockedConcepts = [
+        {
+          id: '33333333-3333-3333-3333-333333333333',
+          projectId: 'proj-1',
+          name: 'Binary Search',
+          slug: 'binary-search',
+          status: 'active',
+          orderIndex: 2,
+        },
+      ];
+
+      mockDbExecute.mockResolvedValueOnce(unblockedConcepts);
+
+      const result = await getReadyToLearnFrontier('proj-1', [masteredId]);
+
+      expect(result).toEqual(unblockedConcepts);
+      expect(mockDbExecute).toHaveBeenCalledTimes(1);
+
+      const executedSql = mockDbExecute.mock.calls[0][0];
+      const sqlString = getSqlString(executedSql);
+      expect(sqlString).toContain('ANY');
+    });
+
+    it('excludes concepts that are already in masteredKcIds', async () => {
+      const masteredId = '11111111-1111-1111-1111-111111111111';
+      mockDbExecute.mockResolvedValueOnce([]);
+
+      const result = await getReadyToLearnFrontier({
+        projectId: 'proj-1',
+        masteredKcIds: [masteredId],
+      });
+
+      expect(result).toEqual([]);
+      expect(mockDbExecute).toHaveBeenCalledTimes(1);
+
+      const executedSql = mockDbExecute.mock.calls[0][0];
+      const sqlString = getSqlString(executedSql);
+      // The SQL query should filter out mastered concepts: NOT (kc.id ... = ANY(...))
+      expect(sqlString).toContain('NOT');
+      expect(sqlString).toContain('ANY');
+    });
+  });
+
+  describe('getExercisesForKc', () => {
+    it('returns empty array when projectId or kcId is empty', async () => {
+      expect(await getExercisesForKc('', 'kc-1')).toEqual([]);
+      expect(await getExercisesForKc('proj-1', '')).toEqual([]);
+      expect(mockDbSelect).not.toHaveBeenCalled();
+    });
+
+    it('returns empty array when concept does not exist in project (tenant isolation)', async () => {
+      const mockLimit = vi.fn().mockResolvedValueOnce([]);
+      mockDbSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: mockLimit }) }),
+      });
+
+      const result = await getExercisesForKc('proj-1', 'non-existent-slug');
+      expect(result).toEqual([]);
+    });
+
+    it('returns exercises directly via WHERE project_id = $1 AND kc_id = $2 without join overhead', async () => {
+      const resolvedConcept = {
+        id: '11111111-1111-1111-1111-111111111111',
+        projectId: 'proj-1',
+        slug: 'binary-search',
+        name: 'Binary Search',
+      };
+      const expectedExercises = [
+        {
+          id: 'ex-1',
+          projectId: 'proj-1',
+          userId: 'user-1',
+          materialId: 'mat-1',
+          kcId: resolvedConcept.id,
+          pageNumber: 42,
+          title: 'Problem 4.2: Peak Element',
+          prompt: 'Find a peak element in an array in O(log n) time.',
+          solution: 'Apply binary search on middle elements.',
+          questionType: 'code',
+          difficulty: 3,
+        },
+      ];
+
+      // 1st select: resolveConcept
+      const mockLimit = vi.fn().mockResolvedValueOnce([resolvedConcept]);
+      mockDbSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: mockLimit }) }),
+      });
+
+      // 2nd select: getExercisesForKc directly from exercises
+      const mockOrderBy = vi.fn().mockResolvedValueOnce(expectedExercises);
+      const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+      const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+      mockDbSelect.mockReturnValueOnce({ from: mockFrom });
+
+      const result = await getExercisesForKc('proj-1', resolvedConcept.id);
+
+      expect(result).toEqual(expectedExercises);
+      expect(mockDbSelect).toHaveBeenCalledTimes(2);
+      expect(mockFrom).toHaveBeenCalledTimes(1);
+    });
+
+    it('supports object options signature { projectId, kcId }', async () => {
+      const resolvedConcept = {
+        id: '11111111-1111-1111-1111-111111111111',
+        projectId: 'proj-1',
+        slug: 'recursion',
+      };
+      mockDbSelect
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi
+              .fn()
+              .mockReturnValue({ limit: vi.fn().mockResolvedValueOnce([resolvedConcept]) }),
+          }),
+        })
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ orderBy: vi.fn().mockResolvedValueOnce([]) }),
+          }),
+        });
+
+      const result = await getExercisesForKc({ projectId: 'proj-1', kcId: 'recursion' });
+      expect(result).toEqual([]);
+      expect(mockDbSelect).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/lib/db/queries/knowledge.test.ts
+++ b/lib/db/queries/knowledge.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  cleanupMaterialExtractedGraph,
+  getActiveProjectConceptNames,
   getKnowledgeComponentsByProjectId,
   getKnowledgeDependenciesByProjectId,
   insertExercises,
@@ -9,13 +11,34 @@ import {
 
 const mockDbInsert = vi.fn();
 const mockDbSelect = vi.fn();
+const mockDbDelete = vi.fn();
+const mockDbTransaction = vi.fn();
 
 vi.mock('@/lib/db', () => ({
   db: {
     insert: (...args: unknown[]) => mockDbInsert(...args),
     select: (...args: unknown[]) => mockDbSelect(...args),
+    delete: (...args: unknown[]) => mockDbDelete(...args),
+    transaction: (...args: unknown[]) => mockDbTransaction(...args),
   },
 }));
+
+function extractChunkText(c: unknown): string {
+  if (typeof c === 'string') return c;
+  if (!c || typeof c !== 'object') return '';
+  if ('value' in c) {
+    const val = (c as { value: unknown }).value;
+    return Array.isArray(val) ? val.join(' ') : String(val);
+  }
+  if ('name' in c) {
+    return String((c as { name: unknown }).name);
+  }
+  return '';
+}
+
+function getSqlString(sqlObj: { queryChunks?: unknown[] }): string {
+  return sqlObj.queryChunks?.map(extractChunkText).join(' ') ?? '';
+}
 
 describe('Knowledge Graph DB Queries', () => {
   beforeEach(() => {
@@ -65,6 +88,35 @@ describe('Knowledge Graph DB Queries', () => {
       expect(mockOnConflictDoUpdate).toHaveBeenCalledTimes(1);
       expect(result).toHaveLength(1);
       expect(result[0].slug).toBe('graphs');
+    });
+
+    it('merges aliases via deduplicated jsonb set union and updates bloomLevel to GREATEST on conflict', async () => {
+      const mockReturning = vi.fn().mockResolvedValueOnce([]);
+      const mockOnConflictDoUpdate = vi.fn().mockReturnValue({ returning: mockReturning });
+      const mockValues = vi.fn().mockReturnValue({ onConflictDoUpdate: mockOnConflictDoUpdate });
+      mockDbInsert.mockReturnValue({ values: mockValues });
+
+      await upsertKnowledgeComponents([
+        {
+          projectId: 'proj-1',
+          userId: 'user-1',
+          slug: 'trees',
+          name: 'Trees',
+          pacerCategory: 'conceptual',
+          bloomLevel: 3,
+          aliases: ['B-Tree'],
+        },
+      ]);
+
+      const conflictUpdateArg = mockOnConflictDoUpdate.mock.calls[0][0];
+      const setClauses = conflictUpdateArg.set;
+
+      const bloomLevelSql = getSqlString(setClauses.bloomLevel);
+      const aliasesSql = getSqlString(setClauses.aliases);
+
+      expect(bloomLevelSql).toContain('GREATEST');
+      expect(aliasesSql).toContain('jsonb_agg(DISTINCT elem)');
+      expect(aliasesSql).toContain('jsonb_array_elements_text');
     });
   });
 
@@ -184,6 +236,73 @@ describe('Knowledge Graph DB Queries', () => {
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe('ex-1');
       expect(result[0].pageNumber).toBe(5);
+    });
+  });
+
+  describe('getActiveProjectConceptNames', () => {
+    it('returns active concept names ordered by updatedAt desc', async () => {
+      const mockLimit = vi
+        .fn()
+        .mockResolvedValueOnce([{ name: 'Binary Search' }, { name: 'Linear Search' }]);
+      const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimit });
+      const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+      const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+      mockDbSelect.mockReturnValue({ from: mockFrom });
+
+      const result = await getActiveProjectConceptNames({ projectId: 'proj-1' });
+
+      expect(mockDbSelect).toHaveBeenCalledTimes(1);
+      expect(mockLimit).toHaveBeenCalledWith(501);
+      expect(result).toEqual(['Binary Search', 'Linear Search']);
+    });
+
+    it('limits to 500 concepts and logs warning when active concepts exceed 500', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {
+        // no-op mock for warning in test
+      });
+      const manyConcepts = Array.from({ length: 501 }, (_, i) => ({
+        name: `Concept ${i + 1}`,
+      }));
+
+      const mockLimit = vi.fn().mockResolvedValueOnce(manyConcepts);
+      const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimit });
+      const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+      const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+      mockDbSelect.mockReturnValue({ from: mockFrom });
+
+      const result = await getActiveProjectConceptNames({ projectId: 'proj-1', limit: 500 });
+
+      expect(result).toHaveLength(500);
+      expect(result[0]).toBe('Concept 1');
+      expect(result[499]).toBe('Concept 500');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('active concepts exceeding limit of 500'),
+      );
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('cleanupMaterialExtractedGraph', () => {
+    it('atomically deletes exercises and material-attributed dependencies in a transaction', async () => {
+      const mockTxDelete = vi.fn();
+      const mockTxWhere = vi.fn().mockResolvedValue(undefined);
+      mockTxDelete.mockReturnValue({ where: mockTxWhere });
+
+      const mockTx = {
+        delete: mockTxDelete,
+      };
+
+      mockDbTransaction.mockImplementation(async (callback: (tx: unknown) => Promise<unknown>) => {
+        return await callback(mockTx);
+      });
+
+      await cleanupMaterialExtractedGraph({
+        materialId: 'mat-1',
+        projectId: 'proj-1',
+      });
+
+      expect(mockDbTransaction).toHaveBeenCalledTimes(1);
+      expect(mockTxDelete).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/lib/db/queries/knowledge.test.ts
+++ b/lib/db/queries/knowledge.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getKnowledgeComponentsByProjectId,
+  getKnowledgeDependenciesByProjectId,
+  insertKnowledgeDependencies,
+  upsertKnowledgeComponents,
+} from './knowledge';
+
+const mockDbInsert = vi.fn();
+const mockDbSelect = vi.fn();
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    insert: (...args: unknown[]) => mockDbInsert(...args),
+    select: (...args: unknown[]) => mockDbSelect(...args),
+  },
+}));
+
+describe('Knowledge Graph DB Queries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('upsertKnowledgeComponents', () => {
+    it('returns empty array when input is empty', async () => {
+      const result = await upsertKnowledgeComponents([]);
+      expect(result).toEqual([]);
+      expect(mockDbInsert).not.toHaveBeenCalled();
+    });
+
+    it('performs insert with onConflictDoUpdate on (projectId, slug)', async () => {
+      const mockReturning = vi.fn().mockResolvedValueOnce([
+        {
+          id: 'kc-1',
+          projectId: 'proj-1',
+          userId: 'user-1',
+          slug: 'graphs',
+          name: 'Graphs',
+          pacerCategory: 'conceptual',
+          bloomLevel: 2,
+          aliases: [],
+          status: 'active',
+          orderIndex: 0,
+        },
+      ]);
+      const mockOnConflictDoUpdate = vi.fn().mockReturnValue({ returning: mockReturning });
+      const mockValues = vi.fn().mockReturnValue({ onConflictDoUpdate: mockOnConflictDoUpdate });
+      mockDbInsert.mockReturnValue({ values: mockValues });
+
+      const result = await upsertKnowledgeComponents([
+        {
+          projectId: 'proj-1',
+          userId: 'user-1',
+          slug: 'graphs',
+          name: 'Graphs',
+          pacerCategory: 'conceptual',
+          bloomLevel: 2,
+          aliases: [],
+        },
+      ]);
+
+      expect(mockDbInsert).toHaveBeenCalledTimes(1);
+      expect(mockValues).toHaveBeenCalledTimes(1);
+      expect(mockOnConflictDoUpdate).toHaveBeenCalledTimes(1);
+      expect(result).toHaveLength(1);
+      expect(result[0].slug).toBe('graphs');
+    });
+  });
+
+  describe('insertKnowledgeDependencies', () => {
+    it('returns empty array when input is empty', async () => {
+      const result = await insertKnowledgeDependencies([]);
+      expect(result).toEqual([]);
+      expect(mockDbInsert).not.toHaveBeenCalled();
+    });
+
+    it('inserts dependencies with onConflictDoNothing', async () => {
+      const mockReturning = vi.fn().mockResolvedValueOnce([
+        {
+          id: 'kd-1',
+          projectId: 'proj-1',
+          sourceKcId: 'kc-1',
+          targetKcId: 'kc-2',
+          relationshipType: 'prerequisite',
+          reasoning: 'Fundamental concept',
+          isTransitive: false,
+        },
+      ]);
+      const mockOnConflictDoNothing = vi.fn().mockReturnValue({ returning: mockReturning });
+      const mockValues = vi.fn().mockReturnValue({ onConflictDoNothing: mockOnConflictDoNothing });
+      mockDbInsert.mockReturnValue({ values: mockValues });
+
+      const result = await insertKnowledgeDependencies([
+        {
+          projectId: 'proj-1',
+          sourceKcId: 'kc-1',
+          targetKcId: 'kc-2',
+          relationshipType: 'prerequisite',
+          reasoning: 'Fundamental concept',
+        },
+      ]);
+
+      expect(mockDbInsert).toHaveBeenCalledTimes(1);
+      expect(mockOnConflictDoNothing).toHaveBeenCalledTimes(1);
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('getKnowledgeComponentsByProjectId', () => {
+    it('selects knowledge components for a project ordered by orderIndex and name', async () => {
+      const mockOrderBy = vi.fn().mockResolvedValueOnce([{ id: 'kc-1', slug: 'bfs' }]);
+      const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+      const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+      mockDbSelect.mockReturnValue({ from: mockFrom });
+
+      const result = await getKnowledgeComponentsByProjectId({ projectId: 'proj-1' });
+
+      expect(mockDbSelect).toHaveBeenCalledTimes(1);
+      expect(mockWhere).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([{ id: 'kc-1', slug: 'bfs' }]);
+    });
+  });
+
+  describe('getKnowledgeDependenciesByProjectId', () => {
+    it('selects knowledge dependencies for a project', async () => {
+      const mockWhere = vi
+        .fn()
+        .mockResolvedValueOnce([{ id: 'kd-1', relationshipType: 'prerequisite' }]);
+      const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+      mockDbSelect.mockReturnValue({ from: mockFrom });
+
+      const result = await getKnowledgeDependenciesByProjectId({ projectId: 'proj-1' });
+
+      expect(mockDbSelect).toHaveBeenCalledTimes(1);
+      expect(mockWhere).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([{ id: 'kd-1', relationshipType: 'prerequisite' }]);
+    });
+  });
+});

--- a/lib/db/queries/knowledge.ts
+++ b/lib/db/queries/knowledge.ts
@@ -287,6 +287,37 @@ async function fetchSecondHopNeighbors(
   return hop2Neighbors;
 }
 
+export async function resolveConcept(
+  projectId: string,
+  kcId: string,
+): Promise<KnowledgeComponent | null> {
+  if (!projectId || !kcId) {
+    return null;
+  }
+
+  try {
+    const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(kcId);
+    const conceptFilter = isUuid
+      ? or(
+          eq(knowledgeComponents.id, kcId),
+          eq(knowledgeComponents.slug, kcId),
+          eq(knowledgeComponents.name, kcId),
+        )
+      : or(eq(knowledgeComponents.slug, kcId), eq(knowledgeComponents.name, kcId));
+
+    const [concept] = await db
+      .select()
+      .from(knowledgeComponents)
+      .where(and(eq(knowledgeComponents.projectId, projectId), conceptFilter))
+      .limit(1);
+
+    return concept ?? null;
+  } catch (error) {
+    if (error instanceof ChatbotError) throw error;
+    throw new ChatbotError('bad_request:database', { cause: error });
+  }
+}
+
 export function getGraphNeighborhood(
   projectId: string,
   kcId: string,
@@ -315,20 +346,7 @@ export async function getGraphNeighborhood(
   }
 
   try {
-    const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(kcId);
-    const conceptFilter = isUuid
-      ? or(
-          eq(knowledgeComponents.id, kcId),
-          eq(knowledgeComponents.slug, kcId),
-          eq(knowledgeComponents.name, kcId),
-        )
-      : or(eq(knowledgeComponents.slug, kcId), eq(knowledgeComponents.name, kcId));
-
-    const [concept] = await db
-      .select()
-      .from(knowledgeComponents)
-      .where(and(eq(knowledgeComponents.projectId, projectId), conceptFilter))
-      .limit(1);
+    const concept = await resolveConcept(projectId, kcId);
 
     if (!concept) {
       return { concept: null, prerequisites: [], unlocked: [], depth: safeDepth };
@@ -365,8 +383,24 @@ export async function getGraphNeighborhood(
       depth: safeDepth,
     };
   } catch (error) {
+    if (error instanceof ChatbotError) throw error;
     throw new ChatbotError('bad_request:database', { cause: error });
   }
+}
+
+function extractExecuteRows<T>(rawRows: unknown): T[] {
+  if (Array.isArray(rawRows)) {
+    return rawRows as T[];
+  }
+  if (
+    rawRows &&
+    typeof rawRows === 'object' &&
+    'rows' in rawRows &&
+    Array.isArray((rawRows as { rows: unknown[] }).rows)
+  ) {
+    return (rawRows as { rows: T[] }).rows;
+  }
+  return [];
 }
 
 export function getPrerequisiteChain(
@@ -397,20 +431,7 @@ export async function getPrerequisiteChain(
   const safeMaxDepth = Math.max(1, Math.min(50, Math.floor(maxDepth)));
 
   try {
-    const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(kcId);
-    const conceptFilter = isUuid
-      ? or(
-          eq(knowledgeComponents.id, kcId),
-          eq(knowledgeComponents.slug, kcId),
-          eq(knowledgeComponents.name, kcId),
-        )
-      : or(eq(knowledgeComponents.slug, kcId), eq(knowledgeComponents.name, kcId));
-
-    const [concept] = await db
-      .select({ id: knowledgeComponents.id })
-      .from(knowledgeComponents)
-      .where(and(eq(knowledgeComponents.projectId, projectId), conceptFilter))
-      .limit(1);
+    const concept = await resolveConcept(projectId, kcId);
 
     if (!concept) {
       return [];
@@ -468,13 +489,131 @@ export async function getPrerequisiteChain(
     `;
 
     const rawRows = await db.execute<PrerequisiteChainNode>(query);
-    const rows = Array.isArray(rawRows)
-      ? rawRows
-      : ((rawRows as unknown as { rows?: PrerequisiteChainNode[] })?.rows ??
-        Array.from((rawRows as unknown as Iterable<PrerequisiteChainNode>) ?? []));
-
-    return rows as PrerequisiteChainNode[];
+    return extractExecuteRows<PrerequisiteChainNode>(rawRows);
   } catch (error) {
+    if (error instanceof ChatbotError) throw error;
+    throw new ChatbotError('bad_request:database', { cause: error });
+  }
+}
+
+export type GetReadyToLearnFrontierOptions = {
+  projectId: string;
+  masteredKcIds?: string[];
+};
+
+export function getReadyToLearnFrontier(
+  projectId: string,
+  masteredKcIds?: string[],
+): Promise<KnowledgeComponent[]>;
+export function getReadyToLearnFrontier(
+  options: GetReadyToLearnFrontierOptions,
+): Promise<KnowledgeComponent[]>;
+export async function getReadyToLearnFrontier(
+  projectIdOrOptions: string | GetReadyToLearnFrontierOptions,
+  masteredKcIdsParam: string[] = [],
+): Promise<KnowledgeComponent[]> {
+  const { projectId, masteredKcIds = [] } =
+    typeof projectIdOrOptions === 'string'
+      ? { projectId: projectIdOrOptions, masteredKcIds: masteredKcIdsParam }
+      : {
+          projectId: projectIdOrOptions.projectId,
+          masteredKcIds: projectIdOrOptions.masteredKcIds ?? [],
+        };
+
+  if (!projectId) {
+    return [];
+  }
+
+  try {
+    const query = sql`
+      WITH unmastered_prereqs AS (
+        SELECT kd.target_kc_id
+        FROM ${knowledgeDependencies} kd
+        WHERE kd.project_id = ${projectId}
+          AND kd.relationship_type = 'prerequisite'
+          ${
+            masteredKcIds.length > 0
+              ? sql`AND NOT (kd.source_kc_id::text = ANY(ARRAY[${sql.join(
+                  masteredKcIds.map((id) => sql`${id}::text`),
+                  sql`, `,
+                )}]))`
+              : sql``
+          }
+      )
+      SELECT
+        kc.id,
+        kc.project_id AS "projectId",
+        kc.user_id AS "userId",
+        kc.slug,
+        kc.name,
+        kc.pacer_category AS "pacerCategory",
+        kc.bloom_level AS "bloomLevel",
+        kc.aliases,
+        kc.status,
+        kc.order_index AS "orderIndex",
+        kc.source_material_id AS "sourceMaterialId",
+        kc.created_at AS "createdAt",
+        kc.updated_at AS "updatedAt"
+      FROM ${knowledgeComponents} kc
+      WHERE kc.project_id = ${projectId}
+        AND kc.status = 'active'
+        ${
+          masteredKcIds.length > 0
+            ? sql`AND NOT (kc.id::text = ANY(ARRAY[${sql.join(
+                masteredKcIds.map((id) => sql`${id}::text`),
+                sql`, `,
+              )}]))`
+            : sql``
+        }
+        AND NOT EXISTS (
+          SELECT 1
+          FROM unmastered_prereqs up
+          WHERE up.target_kc_id = kc.id
+        )
+      ORDER BY kc.order_index ASC, kc.name ASC;
+    `;
+
+    const rawRows = await db.execute<KnowledgeComponent>(query);
+    return extractExecuteRows<KnowledgeComponent>(rawRows);
+  } catch (error) {
+    if (error instanceof ChatbotError) throw error;
+    throw new ChatbotError('bad_request:database', { cause: error });
+  }
+}
+
+export type GetExercisesForKcOptions = {
+  projectId: string;
+  kcId: string;
+};
+
+export function getExercisesForKc(projectId: string, kcId: string): Promise<Exercise[]>;
+export function getExercisesForKc(options: GetExercisesForKcOptions): Promise<Exercise[]>;
+export async function getExercisesForKc(
+  projectIdOrOptions: string | GetExercisesForKcOptions,
+  kcIdParam?: string,
+): Promise<Exercise[]> {
+  const { projectId, kcId } =
+    typeof projectIdOrOptions === 'string'
+      ? { projectId: projectIdOrOptions, kcId: kcIdParam ?? '' }
+      : projectIdOrOptions;
+
+  if (!projectId || !kcId) {
+    return [];
+  }
+
+  try {
+    const concept = await resolveConcept(projectId, kcId);
+    if (!concept) {
+      return [];
+    }
+
+    return await db
+      .select()
+      .from(exercises)
+      .where(and(eq(exercises.projectId, projectId), eq(exercises.kcId, concept.id)))
+      .orderBy(asc(exercises.pageNumber), asc(exercises.title));
+  } catch (error) {
+    if (error instanceof ChatbotError) throw error;
     throw new ChatbotError('bad_request:database', { cause: error });
   }
 }

--- a/lib/db/queries/knowledge.ts
+++ b/lib/db/queries/knowledge.ts
@@ -1,0 +1,97 @@
+import { asc, eq, sql } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import {
+  type KnowledgeComponent,
+  type KnowledgeDependency,
+  knowledgeComponents,
+  knowledgeDependencies,
+  type NewKnowledgeComponent,
+  type NewKnowledgeDependency,
+} from '@/lib/db/schema';
+import { ChatbotError } from '@/lib/errors';
+
+export async function upsertKnowledgeComponents(
+  components: NewKnowledgeComponent[],
+): Promise<KnowledgeComponent[]> {
+  if (!components || components.length === 0) {
+    return [];
+  }
+
+  try {
+    return await db
+      .insert(knowledgeComponents)
+      .values(components)
+      .onConflictDoUpdate({
+        target: [knowledgeComponents.projectId, knowledgeComponents.slug],
+        set: {
+          name: sql`EXCLUDED.name`,
+          pacerCategory: sql`EXCLUDED.pacer_category`,
+          bloomLevel: sql`EXCLUDED.bloom_level`,
+          aliases: sql`EXCLUDED.aliases`,
+          status: sql`EXCLUDED.status`,
+          orderIndex: sql`EXCLUDED.order_index`,
+          sourceMaterialId: sql`COALESCE(${knowledgeComponents.sourceMaterialId}, EXCLUDED.source_material_id)`,
+          updatedAt: new Date(),
+        },
+      })
+      .returning();
+  } catch (error) {
+    throw new ChatbotError('bad_request:database', { cause: error });
+  }
+}
+
+export async function insertKnowledgeDependencies(
+  dependencies: NewKnowledgeDependency[],
+): Promise<KnowledgeDependency[]> {
+  if (!dependencies || dependencies.length === 0) {
+    return [];
+  }
+
+  try {
+    return await db
+      .insert(knowledgeDependencies)
+      .values(dependencies)
+      .onConflictDoNothing({
+        target: [
+          knowledgeDependencies.projectId,
+          knowledgeDependencies.sourceKcId,
+          knowledgeDependencies.targetKcId,
+          knowledgeDependencies.relationshipType,
+        ],
+      })
+      .returning();
+  } catch (error) {
+    throw new ChatbotError('bad_request:database', { cause: error });
+  }
+}
+
+export async function getKnowledgeComponentsByProjectId({
+  projectId,
+}: {
+  projectId: string;
+}): Promise<KnowledgeComponent[]> {
+  try {
+    return await db
+      .select()
+      .from(knowledgeComponents)
+      .where(eq(knowledgeComponents.projectId, projectId))
+      .orderBy(asc(knowledgeComponents.orderIndex), asc(knowledgeComponents.name));
+  } catch (error) {
+    throw new ChatbotError('bad_request:database', { cause: error });
+  }
+}
+
+export async function getKnowledgeDependenciesByProjectId({
+  projectId,
+}: {
+  projectId: string;
+}): Promise<KnowledgeDependency[]> {
+  try {
+    return await db
+      .select()
+      .from(knowledgeDependencies)
+      .where(eq(knowledgeDependencies.projectId, projectId));
+  } catch (error) {
+    throw new ChatbotError('bad_request:database', { cause: error });
+  }
+}

--- a/lib/db/queries/knowledge.ts
+++ b/lib/db/queries/knowledge.ts
@@ -1,4 +1,4 @@
-import { asc, eq, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, sql } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import {
   type Exercise,
@@ -29,8 +29,11 @@ export async function upsertKnowledgeComponents(
         set: {
           name: sql`EXCLUDED.name`,
           pacerCategory: sql`EXCLUDED.pacer_category`,
-          bloomLevel: sql`EXCLUDED.bloom_level`,
-          aliases: sql`EXCLUDED.aliases`,
+          bloomLevel: sql`GREATEST(${knowledgeComponents.bloomLevel}, EXCLUDED.bloom_level)`,
+          aliases: sql`(
+            SELECT COALESCE(jsonb_agg(DISTINCT elem), '[]'::jsonb)
+            FROM jsonb_array_elements_text(${knowledgeComponents.aliases} || EXCLUDED.aliases) AS elem
+          )`,
           status: sql`EXCLUDED.status`,
           orderIndex: sql`EXCLUDED.order_index`,
           sourceMaterialId: sql`COALESCE(${knowledgeComponents.sourceMaterialId}, EXCLUDED.source_material_id)`,
@@ -106,6 +109,64 @@ export async function insertExercises(exercisesToInsert: NewExercise[]): Promise
 
   try {
     return await db.insert(exercises).values(exercisesToInsert).returning();
+  } catch (error) {
+    throw new ChatbotError('bad_request:database', { cause: error });
+  }
+}
+
+export async function getActiveProjectConceptNames({
+  projectId,
+  limit = 500,
+}: {
+  projectId: string;
+  limit?: number;
+}): Promise<string[]> {
+  try {
+    const rows = await db
+      .select({
+        name: knowledgeComponents.name,
+      })
+      .from(knowledgeComponents)
+      .where(
+        and(eq(knowledgeComponents.projectId, projectId), eq(knowledgeComponents.status, 'active')),
+      )
+      .orderBy(desc(knowledgeComponents.updatedAt))
+      .limit(limit + 1);
+
+    if (rows.length > limit) {
+      console.warn(
+        `[vocabulary-grounding] Project ${projectId} has active concepts exceeding limit of ${limit}. Using the ${limit} most recently updated concepts.`,
+      );
+      return rows.slice(0, limit).map((r) => r.name);
+    }
+
+    return rows.map((r) => r.name);
+  } catch (error) {
+    throw new ChatbotError('bad_request:database', { cause: error });
+  }
+}
+
+export async function cleanupMaterialExtractedGraph({
+  materialId,
+  projectId,
+}: {
+  materialId: string;
+  projectId: string;
+}): Promise<void> {
+  try {
+    await db.transaction(async (tx) => {
+      await tx
+        .delete(exercises)
+        .where(and(eq(exercises.materialId, materialId), eq(exercises.projectId, projectId)));
+      await tx
+        .delete(knowledgeDependencies)
+        .where(
+          and(
+            eq(knowledgeDependencies.sourceMaterialId, materialId),
+            eq(knowledgeDependencies.projectId, projectId),
+          ),
+        );
+    });
   } catch (error) {
     throw new ChatbotError('bad_request:database', { cause: error });
   }

--- a/lib/db/queries/knowledge.ts
+++ b/lib/db/queries/knowledge.ts
@@ -1,10 +1,13 @@
 import { asc, eq, sql } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import {
+  type Exercise,
+  exercises,
   type KnowledgeComponent,
   type KnowledgeDependency,
   knowledgeComponents,
   knowledgeDependencies,
+  type NewExercise,
   type NewKnowledgeComponent,
   type NewKnowledgeDependency,
 } from '@/lib/db/schema';
@@ -91,6 +94,18 @@ export async function getKnowledgeDependenciesByProjectId({
       .select()
       .from(knowledgeDependencies)
       .where(eq(knowledgeDependencies.projectId, projectId));
+  } catch (error) {
+    throw new ChatbotError('bad_request:database', { cause: error });
+  }
+}
+
+export async function insertExercises(exercisesToInsert: NewExercise[]): Promise<Exercise[]> {
+  if (!exercisesToInsert || exercisesToInsert.length === 0) {
+    return [];
+  }
+
+  try {
+    return await db.insert(exercises).values(exercisesToInsert).returning();
   } catch (error) {
     throw new ChatbotError('bad_request:database', { cause: error });
   }

--- a/lib/db/queries/knowledge.ts
+++ b/lib/db/queries/knowledge.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, or, sql } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import {
   type Exercise,
@@ -12,6 +12,39 @@ import {
   type NewKnowledgeDependency,
 } from '@/lib/db/schema';
 import { ChatbotError } from '@/lib/errors';
+
+export type GraphNeighborKC = KnowledgeComponent & {
+  depth: number;
+  relationshipType?: string;
+  reasoning?: string | null;
+};
+
+export type GraphNeighborConcept = GraphNeighborKC;
+
+export type GraphNeighborhoodResult = {
+  concept: KnowledgeComponent | null;
+  prerequisites: GraphNeighborKC[];
+  unlocked: GraphNeighborKC[];
+  depth: number;
+};
+
+export type GetGraphNeighborhoodOptions = {
+  projectId: string;
+  kcId: string;
+  depth?: number;
+};
+
+export type PrerequisiteChainNode = KnowledgeComponent & {
+  depth: number;
+  relationshipType?: string;
+  reasoning?: string | null;
+};
+
+export type GetPrerequisiteChainOptions = {
+  projectId: string;
+  kcId: string;
+  maxDepth?: number;
+};
 
 export async function upsertKnowledgeComponents(
   components: NewKnowledgeComponent[],
@@ -167,6 +200,280 @@ export async function cleanupMaterialExtractedGraph({
           ),
         );
     });
+  } catch (error) {
+    throw new ChatbotError('bad_request:database', { cause: error });
+  }
+}
+
+async function fetchDirectNeighbors(
+  projectId: string,
+  kcId: string,
+  direction: 'prerequisites' | 'unlocked',
+): Promise<GraphNeighborKC[]> {
+  const isPrereq = direction === 'prerequisites';
+  const joinCondition = isPrereq
+    ? eq(knowledgeComponents.id, knowledgeDependencies.sourceKcId)
+    : eq(knowledgeComponents.id, knowledgeDependencies.targetKcId);
+  const whereCondition = isPrereq
+    ? eq(knowledgeDependencies.targetKcId, kcId)
+    : eq(knowledgeDependencies.sourceKcId, kcId);
+
+  const rows = await db
+    .select({
+      concept: knowledgeComponents,
+      dependency: {
+        relationshipType: knowledgeDependencies.relationshipType,
+        reasoning: knowledgeDependencies.reasoning,
+      },
+    })
+    .from(knowledgeDependencies)
+    .innerJoin(
+      knowledgeComponents,
+      and(joinCondition, eq(knowledgeComponents.projectId, projectId)),
+    )
+    .where(and(eq(knowledgeDependencies.projectId, projectId), whereCondition));
+
+  return rows.map((row) => ({
+    ...row.concept,
+    depth: 1,
+    relationshipType: row.dependency.relationshipType,
+    reasoning: row.dependency.reasoning,
+  }));
+}
+
+async function fetchSecondHopNeighbors(
+  projectId: string,
+  hop1Ids: string[],
+  visitedIds: Set<string>,
+  direction: 'prerequisites' | 'unlocked',
+): Promise<GraphNeighborKC[]> {
+  if (hop1Ids.length === 0) return [];
+
+  const isPrereq = direction === 'prerequisites';
+  const joinCondition = isPrereq
+    ? eq(knowledgeComponents.id, knowledgeDependencies.sourceKcId)
+    : eq(knowledgeComponents.id, knowledgeDependencies.targetKcId);
+  const whereCondition = isPrereq
+    ? inArray(knowledgeDependencies.targetKcId, hop1Ids)
+    : inArray(knowledgeDependencies.sourceKcId, hop1Ids);
+
+  const rows = await db
+    .select({
+      concept: knowledgeComponents,
+      dependency: {
+        relationshipType: knowledgeDependencies.relationshipType,
+        reasoning: knowledgeDependencies.reasoning,
+      },
+    })
+    .from(knowledgeDependencies)
+    .innerJoin(
+      knowledgeComponents,
+      and(joinCondition, eq(knowledgeComponents.projectId, projectId)),
+    )
+    .where(and(eq(knowledgeDependencies.projectId, projectId), whereCondition));
+
+  const hop2Neighbors: GraphNeighborKC[] = [];
+  for (const row of rows) {
+    if (!visitedIds.has(row.concept.id)) {
+      visitedIds.add(row.concept.id);
+      hop2Neighbors.push({
+        ...row.concept,
+        depth: 2,
+        relationshipType: row.dependency.relationshipType,
+        reasoning: row.dependency.reasoning,
+      });
+    }
+  }
+  return hop2Neighbors;
+}
+
+export function getGraphNeighborhood(
+  projectId: string,
+  kcId: string,
+  depth?: number,
+): Promise<GraphNeighborhoodResult>;
+export function getGraphNeighborhood(
+  options: GetGraphNeighborhoodOptions,
+): Promise<GraphNeighborhoodResult>;
+export async function getGraphNeighborhood(
+  projectIdOrOptions: string | GetGraphNeighborhoodOptions,
+  kcIdParam?: string,
+  depthParam = 1,
+): Promise<GraphNeighborhoodResult> {
+  const {
+    projectId,
+    kcId,
+    depth = 1,
+  } = typeof projectIdOrOptions === 'string'
+    ? { projectId: projectIdOrOptions, kcId: kcIdParam ?? '', depth: depthParam }
+    : projectIdOrOptions;
+
+  const safeDepth = Math.max(1, Math.min(2, Math.floor(depth)));
+
+  if (!projectId || !kcId) {
+    return { concept: null, prerequisites: [], unlocked: [], depth: safeDepth };
+  }
+
+  try {
+    const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(kcId);
+    const conceptFilter = isUuid
+      ? or(
+          eq(knowledgeComponents.id, kcId),
+          eq(knowledgeComponents.slug, kcId),
+          eq(knowledgeComponents.name, kcId),
+        )
+      : or(eq(knowledgeComponents.slug, kcId), eq(knowledgeComponents.name, kcId));
+
+    const [concept] = await db
+      .select()
+      .from(knowledgeComponents)
+      .where(and(eq(knowledgeComponents.projectId, projectId), conceptFilter))
+      .limit(1);
+
+    if (!concept) {
+      return { concept: null, prerequisites: [], unlocked: [], depth: safeDepth };
+    }
+
+    const hop1Prereqs = await fetchDirectNeighbors(projectId, concept.id, 'prerequisites');
+    const hop1Unlocked = await fetchDirectNeighbors(projectId, concept.id, 'unlocked');
+
+    let hop2Prereqs: GraphNeighborKC[] = [];
+    let hop2Unlocked: GraphNeighborKC[] = [];
+
+    if (safeDepth === 2) {
+      const visitedPrereqs = new Set([concept.id, ...hop1Prereqs.map((p) => p.id)]);
+      hop2Prereqs = await fetchSecondHopNeighbors(
+        projectId,
+        hop1Prereqs.map((p) => p.id),
+        visitedPrereqs,
+        'prerequisites',
+      );
+
+      const visitedUnlocked = new Set([concept.id, ...hop1Unlocked.map((u) => u.id)]);
+      hop2Unlocked = await fetchSecondHopNeighbors(
+        projectId,
+        hop1Unlocked.map((u) => u.id),
+        visitedUnlocked,
+        'unlocked',
+      );
+    }
+
+    return {
+      concept,
+      prerequisites: [...hop1Prereqs, ...hop2Prereqs],
+      unlocked: [...hop1Unlocked, ...hop2Unlocked],
+      depth: safeDepth,
+    };
+  } catch (error) {
+    throw new ChatbotError('bad_request:database', { cause: error });
+  }
+}
+
+export function getPrerequisiteChain(
+  projectId: string,
+  kcId: string,
+  maxDepth?: number,
+): Promise<PrerequisiteChainNode[]>;
+export function getPrerequisiteChain(
+  options: GetPrerequisiteChainOptions,
+): Promise<PrerequisiteChainNode[]>;
+export async function getPrerequisiteChain(
+  projectIdOrOptions: string | GetPrerequisiteChainOptions,
+  kcIdParam?: string,
+  maxDepthParam = 10,
+): Promise<PrerequisiteChainNode[]> {
+  const {
+    projectId,
+    kcId,
+    maxDepth = 10,
+  } = typeof projectIdOrOptions === 'string'
+    ? { projectId: projectIdOrOptions, kcId: kcIdParam ?? '', maxDepth: maxDepthParam }
+    : projectIdOrOptions;
+
+  if (!projectId || !kcId) {
+    return [];
+  }
+
+  const safeMaxDepth = Math.max(1, Math.min(50, Math.floor(maxDepth)));
+
+  try {
+    const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(kcId);
+    const conceptFilter = isUuid
+      ? or(
+          eq(knowledgeComponents.id, kcId),
+          eq(knowledgeComponents.slug, kcId),
+          eq(knowledgeComponents.name, kcId),
+        )
+      : or(eq(knowledgeComponents.slug, kcId), eq(knowledgeComponents.name, kcId));
+
+    const [concept] = await db
+      .select({ id: knowledgeComponents.id })
+      .from(knowledgeComponents)
+      .where(and(eq(knowledgeComponents.projectId, projectId), conceptFilter))
+      .limit(1);
+
+    if (!concept) {
+      return [];
+    }
+
+    const query = sql`
+      WITH RECURSIVE prereq_tree AS (
+        SELECT
+          kd.source_kc_id AS kc_id,
+          kd.target_kc_id AS dependent_kc_id,
+          1 AS depth,
+          ARRAY[kd.target_kc_id::text, kd.source_kc_id::text] AS visited_path,
+          kd.relationship_type,
+          kd.reasoning
+        FROM ${knowledgeDependencies} kd
+        WHERE kd.project_id = ${projectId}
+          AND kd.target_kc_id = ${concept.id}
+
+        UNION ALL
+
+        SELECT
+          kd.source_kc_id AS kc_id,
+          kd.target_kc_id AS dependent_kc_id,
+          prev.depth + 1 AS depth,
+          prev.visited_path || kd.source_kc_id::text AS visited_path,
+          kd.relationship_type,
+          kd.reasoning
+        FROM ${knowledgeDependencies} kd
+        JOIN prereq_tree prev ON kd.target_kc_id = prev.kc_id
+        WHERE kd.project_id = ${projectId}
+          AND prev.depth < ${safeMaxDepth}
+          AND NOT (kd.source_kc_id::text = ANY(prev.visited_path))
+      ),
+      distinct_ancestors AS (
+        SELECT DISTINCT ON (pt.kc_id)
+          kc.id,
+          kc.project_id AS "projectId",
+          kc.user_id AS "userId",
+          kc.slug,
+          kc.name,
+          kc.pacer_category AS "pacerCategory",
+          kc.bloom_level AS "bloomLevel",
+          kc.aliases,
+          kc.status,
+          kc.order_index AS "orderIndex",
+          kc.source_material_id AS "sourceMaterialId",
+          pt.depth,
+          pt.relationship_type AS "relationshipType",
+          pt.reasoning
+        FROM prereq_tree pt
+        JOIN ${knowledgeComponents} kc ON kc.id = pt.kc_id AND kc.project_id = ${projectId}
+        ORDER BY pt.kc_id, pt.depth ASC
+      )
+      SELECT * FROM distinct_ancestors ORDER BY depth ASC, "orderIndex" ASC, name ASC;
+    `;
+
+    const rawRows = await db.execute<PrerequisiteChainNode>(query);
+    const rows = Array.isArray(rawRows)
+      ? rawRows
+      : ((rawRows as unknown as { rows?: PrerequisiteChainNode[] })?.rows ??
+        Array.from((rawRows as unknown as Iterable<PrerequisiteChainNode>) ?? []));
+
+    return rows as PrerequisiteChainNode[];
   } catch (error) {
     throw new ChatbotError('bad_request:database', { cause: error });
   }

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -1,4 +1,5 @@
 export * from './chats';
+export * from './knowledge';
 export * from './materials';
 export * from './profiles';
 export * from './projects';

--- a/lib/db/schema/knowledge.test.ts
+++ b/lib/db/schema/knowledge.test.ts
@@ -1,6 +1,13 @@
+import { getTableConfig } from 'drizzle-orm/pg-core';
 import { describe, expect, it } from 'vitest';
 import * as schemaExports from './index';
-import { knowledgeComponents, knowledgeDependencies, PACER_CATEGORIES } from './knowledge';
+import {
+  EXERCISE_QUESTION_TYPES,
+  exercises,
+  knowledgeComponents,
+  knowledgeDependencies,
+  PACER_CATEGORIES,
+} from './knowledge';
 
 describe('Drizzle Knowledge Graph Schema', () => {
   it('exports knowledgeComponents and knowledgeDependencies schema objects', () => {
@@ -47,5 +54,63 @@ describe('Drizzle Knowledge Graph Schema', () => {
       'evidence',
       'reference',
     ]);
+  });
+
+  it('exports exercises schema object and EXERCISE_QUESTION_TYPES', () => {
+    expect(exercises).toBeDefined();
+    expect(schemaExports.exercises).toBe(exercises);
+    expect(EXERCISE_QUESTION_TYPES).toEqual([
+      'multiple_choice',
+      'calculation',
+      'conceptual',
+      'code',
+    ]);
+  });
+
+  it('defines correct exercises table columns and types', () => {
+    expect(exercises.id).toBeDefined();
+    expect(exercises.projectId).toBeDefined();
+    expect(exercises.userId).toBeDefined();
+    expect(exercises.materialId).toBeDefined();
+    expect(exercises.kcId).toBeDefined();
+    expect(exercises.pageNumber).toBeDefined();
+    expect(exercises.title).toBeDefined();
+    expect(exercises.prompt).toBeDefined();
+    expect(exercises.solution).toBeDefined();
+    expect(exercises.questionType).toBeDefined();
+    expect(exercises.difficulty).toBeDefined();
+    expect(exercises.createdAt).toBeDefined();
+  });
+
+  it('configures cascade deletion on exercises foreign keys while preserving knowledgeComponents', () => {
+    const exercisesConfig = getTableConfig(exercises);
+    const kcConfig = getTableConfig(knowledgeComponents);
+
+    const fks = exercisesConfig.foreignKeys;
+    expect(fks.length).toBe(4);
+
+    // All 4 FKs on exercises should be onDelete: 'cascade'
+    for (const fk of fks) {
+      expect(fk.onDelete).toBe('cascade');
+    }
+
+    // Identify specific foreign keys by their local columns
+    const materialFk = fks.find((fk) =>
+      fk.reference().columns.some((col) => col.name === 'material_id'),
+    );
+    expect(materialFk).toBeDefined();
+    expect(materialFk?.onDelete).toBe('cascade');
+
+    const kcFk = fks.find((fk) => fk.reference().columns.some((col) => col.name === 'kc_id'));
+    expect(kcFk).toBeDefined();
+    expect(kcFk?.onDelete).toBe('cascade');
+
+    // For knowledgeComponents: sourceMaterialId is onDelete: set null (preserving KCs upon material deletion)
+    const kcFks = kcConfig.foreignKeys;
+    const kcMaterialFk = kcFks.find((fk) =>
+      fk.reference().columns.some((col) => col.name === 'source_material_id'),
+    );
+    expect(kcMaterialFk).toBeDefined();
+    expect(kcMaterialFk?.onDelete).toBe('set null');
   });
 });

--- a/lib/db/schema/knowledge.test.ts
+++ b/lib/db/schema/knowledge.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import * as schemaExports from './index';
+import { knowledgeComponents, knowledgeDependencies, PACER_CATEGORIES } from './knowledge';
+
+describe('Drizzle Knowledge Graph Schema', () => {
+  it('exports knowledgeComponents and knowledgeDependencies schema objects', () => {
+    expect(knowledgeComponents).toBeDefined();
+    expect(knowledgeDependencies).toBeDefined();
+    expect(schemaExports.knowledgeComponents).toBe(knowledgeComponents);
+    expect(schemaExports.knowledgeDependencies).toBe(knowledgeDependencies);
+  });
+
+  it('defines correct knowledgeComponents table columns and types', () => {
+    expect(knowledgeComponents.id).toBeDefined();
+    expect(knowledgeComponents.projectId).toBeDefined();
+    expect(knowledgeComponents.userId).toBeDefined();
+    expect(knowledgeComponents.slug).toBeDefined();
+    expect(knowledgeComponents.name).toBeDefined();
+    expect(knowledgeComponents.pacerCategory).toBeDefined();
+    expect(knowledgeComponents.bloomLevel).toBeDefined();
+    expect(knowledgeComponents.aliases).toBeDefined();
+    expect(knowledgeComponents.embedding).toBeDefined();
+    expect(knowledgeComponents.sourceMaterialId).toBeDefined();
+    expect(knowledgeComponents.status).toBeDefined();
+    expect(knowledgeComponents.orderIndex).toBeDefined();
+    expect(knowledgeComponents.createdAt).toBeDefined();
+    expect(knowledgeComponents.updatedAt).toBeDefined();
+  });
+
+  it('defines correct knowledgeDependencies table columns and types', () => {
+    expect(knowledgeDependencies.id).toBeDefined();
+    expect(knowledgeDependencies.projectId).toBeDefined();
+    expect(knowledgeDependencies.sourceKcId).toBeDefined();
+    expect(knowledgeDependencies.targetKcId).toBeDefined();
+    expect(knowledgeDependencies.relationshipType).toBeDefined();
+    expect(knowledgeDependencies.reasoning).toBeDefined();
+    expect(knowledgeDependencies.isTransitive).toBeDefined();
+    expect(knowledgeDependencies.sourceMaterialId).toBeDefined();
+    expect(knowledgeDependencies.createdAt).toBeDefined();
+  });
+
+  it('exports valid PACER_CATEGORIES matching the spec', () => {
+    expect(PACER_CATEGORIES).toEqual([
+      'procedural',
+      'analogous',
+      'conceptual',
+      'evidence',
+      'reference',
+    ]);
+  });
+});

--- a/lib/db/schema/knowledge.ts
+++ b/lib/db/schema/knowledge.ts
@@ -92,3 +92,46 @@ export const knowledgeDependencies = pgTable(
 
 export type KnowledgeDependency = typeof knowledgeDependencies.$inferSelect;
 export type NewKnowledgeDependency = typeof knowledgeDependencies.$inferInsert;
+
+export const EXERCISE_QUESTION_TYPES = [
+  'multiple_choice',
+  'calculation',
+  'conceptual',
+  'code',
+] as const;
+
+export type ExerciseQuestionType = (typeof EXERCISE_QUESTION_TYPES)[number];
+
+export const exercises = pgTable(
+  'exercises',
+  {
+    id: uuid('id').primaryKey().notNull().defaultRandom(),
+    projectId: uuid('project_id')
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade' }),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => authUsers.id, { onDelete: 'cascade' }),
+    materialId: uuid('material_id')
+      .notNull()
+      .references(() => materials.id, { onDelete: 'cascade' }),
+    kcId: uuid('kc_id')
+      .notNull()
+      .references(() => knowledgeComponents.id, { onDelete: 'cascade' }),
+    pageNumber: integer('page_number').notNull(),
+    title: text('title'),
+    prompt: text('prompt'),
+    solution: text('solution'),
+    questionType: text('question_type').$type<ExerciseQuestionType>().notNull(),
+    difficulty: integer('difficulty').notNull().default(1),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index('idx_exercises_project').on(table.projectId),
+    index('idx_exercises_material').on(table.materialId),
+    index('idx_exercises_kc').on(table.kcId),
+  ],
+);
+
+export type Exercise = typeof exercises.$inferSelect;
+export type NewExercise = typeof exercises.$inferInsert;

--- a/lib/db/schema/knowledge.ts
+++ b/lib/db/schema/knowledge.ts
@@ -1,0 +1,94 @@
+import {
+  boolean,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  vector,
+} from 'drizzle-orm/pg-core';
+import { materials } from './materials';
+import { authUsers } from './profiles';
+import { projects } from './projects';
+
+export const PACER_CATEGORIES = [
+  'procedural',
+  'analogous',
+  'conceptual',
+  'evidence',
+  'reference',
+] as const;
+
+export type PacerCategory = (typeof PACER_CATEGORIES)[number];
+
+export const knowledgeComponents = pgTable(
+  'knowledge_components',
+  {
+    id: uuid('id').primaryKey().notNull().defaultRandom(),
+    projectId: uuid('project_id')
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade' }),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => authUsers.id, { onDelete: 'cascade' }),
+    slug: text('slug').notNull(),
+    name: text('name').notNull(),
+    pacerCategory: text('pacer_category').$type<PacerCategory>().notNull(),
+    bloomLevel: integer('bloom_level').notNull(),
+    aliases: jsonb('aliases').$type<string[]>().notNull().default([]),
+    embedding: vector('embedding', { dimensions: 768 }),
+    sourceMaterialId: uuid('source_material_id').references(() => materials.id, {
+      onDelete: 'set null',
+    }),
+    status: text('status').notNull().default('active'),
+    orderIndex: integer('order_index').notNull().default(0),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('idx_kc_project_slug').on(table.projectId, table.slug),
+    index('idx_kc_project_id').on(table.projectId),
+  ],
+);
+
+export type KnowledgeComponent = typeof knowledgeComponents.$inferSelect;
+export type NewKnowledgeComponent = typeof knowledgeComponents.$inferInsert;
+
+export const knowledgeDependencies = pgTable(
+  'knowledge_dependencies',
+  {
+    id: uuid('id').primaryKey().notNull().defaultRandom(),
+    projectId: uuid('project_id')
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade' }),
+    sourceKcId: uuid('source_kc_id')
+      .notNull()
+      .references(() => knowledgeComponents.id, { onDelete: 'cascade' }),
+    targetKcId: uuid('target_kc_id')
+      .notNull()
+      .references(() => knowledgeComponents.id, { onDelete: 'cascade' }),
+    relationshipType: text('relationship_type').notNull().default('prerequisite'),
+    reasoning: text('reasoning'),
+    isTransitive: boolean('is_transitive').notNull().default(false),
+    sourceMaterialId: uuid('source_material_id').references(() => materials.id, {
+      onDelete: 'set null',
+    }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('idx_kd_project_source_target_rel').on(
+      table.projectId,
+      table.sourceKcId,
+      table.targetKcId,
+      table.relationshipType,
+    ),
+    index('idx_kd_project_target').on(table.projectId, table.targetKcId),
+    index('idx_kd_project_source').on(table.projectId, table.sourceKcId),
+  ],
+);
+
+export type KnowledgeDependency = typeof knowledgeDependencies.$inferSelect;
+export type NewKnowledgeDependency = typeof knowledgeDependencies.$inferInsert;

--- a/lib/db/schema/materials.test.ts
+++ b/lib/db/schema/materials.test.ts
@@ -35,7 +35,16 @@ describe('Drizzle Materials Schema', () => {
     expect(materialChunks.content).toBeDefined();
     expect(materialChunks.tokenCount).toBeDefined();
     expect(materialChunks.embedding).toBeDefined();
-    expect(materialChunks.metadata).toBeDefined();
     expect(materialChunks.createdAt).toBeDefined();
+  });
+
+  it('exports graph extraction metadata types and constants', () => {
+    expect(schemaExports.GRAPH_EXTRACTION_STATUSES).toBeDefined();
+    expect(schemaExports.GRAPH_EXTRACTION_STATUSES).toContain('not_started');
+    expect(schemaExports.GRAPH_EXTRACTION_STATUSES).toContain('queued');
+    expect(schemaExports.GRAPH_EXTRACTION_STATUSES).toContain('extracting');
+    expect(schemaExports.GRAPH_EXTRACTION_STATUSES).toContain('ready');
+    expect(schemaExports.GRAPH_EXTRACTION_STATUSES).toContain('ready_with_warnings');
+    expect(schemaExports.GRAPH_EXTRACTION_STATUSES).toContain('failed');
   });
 });

--- a/lib/db/schema/materials.ts
+++ b/lib/db/schema/materials.ts
@@ -12,7 +12,14 @@ import {
 import { authUsers } from './profiles';
 import { projects } from './projects';
 
+export {
+  GRAPH_EXTRACTION_STATUSES,
+  type GraphExtractionStatus,
+  type MaterialGraphExtractionMetadata,
+} from '@/lib/materials/types';
+
 export const materialStatusEnum = ['pending', 'processing', 'ready', 'failed'] as const;
+
 export type MaterialStatus = (typeof materialStatusEnum)[number];
 
 export const materials = pgTable(

--- a/lib/hooks/use-materials.test.ts
+++ b/lib/hooks/use-materials.test.ts
@@ -24,6 +24,30 @@ describe('useMaterials Hook Helpers', () => {
     expect(calculateMaterialsRefreshInterval(data)).toBe(2500);
   });
 
+  it('returns 2500ms when any material has graphExtraction status queued or extracting', () => {
+    const queuedData = {
+      materials: [
+        {
+          id: '1',
+          status: 'ready' as const,
+          metadata: { graphExtraction: { status: 'queued' as const } },
+        },
+      ] as MaterialItem[],
+    };
+    expect(calculateMaterialsRefreshInterval(queuedData)).toBe(2500);
+
+    const extractingData = {
+      materials: [
+        {
+          id: '1',
+          status: 'ready' as const,
+          metadata: { graphExtraction: { status: 'extracting' as const } },
+        },
+      ] as MaterialItem[],
+    };
+    expect(calculateMaterialsRefreshInterval(extractingData)).toBe(2500);
+  });
+
   it('returns 0 (idling) when all materials are in terminal states (ready or failed)', () => {
     const data = {
       materials: [

--- a/lib/hooks/use-materials.ts
+++ b/lib/hooks/use-materials.ts
@@ -1,8 +1,10 @@
 'use client';
 
 import useSWR from 'swr';
+import type { GraphExtractionStatus, MaterialGraphExtractionMetadata } from '@/lib/materials/types';
 import { fetcher } from '@/lib/utils';
 
+export type { GraphExtractionStatus, MaterialGraphExtractionMetadata };
 export type MaterialStatus = 'pending' | 'processing' | 'ready' | 'failed';
 
 export type MaterialProgress = {
@@ -18,6 +20,7 @@ export type MaterialMetadata = {
   chunkCount?: number;
   tokenCount?: number;
   progress?: MaterialProgress;
+  graphExtraction?: MaterialGraphExtractionMetadata;
   error?: {
     message?: string;
     stage?: string;
@@ -48,17 +51,23 @@ export type MaterialsResponse = {
 };
 
 export function calculateMaterialsRefreshInterval(
-  data?: MaterialsResponse | { materials?: { status: MaterialStatus }[] },
+  data?:
+    | MaterialsResponse
+    | { materials?: { status: MaterialStatus; metadata?: MaterialMetadata }[] },
 ): number {
   if (!data?.materials || data.materials.length === 0) {
     return 0;
   }
 
-  const hasActiveIngestion = data.materials.some(
-    (m) => m.status === 'pending' || m.status === 'processing',
-  );
+  const hasActiveProcessing = data.materials.some((m) => {
+    const isIngesting = m.status === 'pending' || m.status === 'processing';
+    const isExtractingGraph =
+      m.metadata?.graphExtraction?.status === 'queued' ||
+      m.metadata?.graphExtraction?.status === 'extracting';
+    return isIngesting || isExtractingGraph;
+  });
 
-  return hasActiveIngestion ? 2500 : 0;
+  return hasActiveProcessing ? 2500 : 0;
 }
 
 export function useMaterials(projectId?: string | null) {

--- a/lib/materials/concept-extraction.test.ts
+++ b/lib/materials/concept-extraction.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from 'vitest';
+import type { MaterialChunk } from '@/lib/db/schema';
+import {
+  conceptExtractionSchema,
+  sanitizeExtractedGraph,
+  sliceMaterialChunksIntoBatches,
+  slugifyConceptName,
+} from './concept-extraction';
+
+describe('Concept Extraction Domain Logic', () => {
+  describe('slugifyConceptName', () => {
+    it('deterministically slugifies concept names into kebab-case', () => {
+      expect(slugifyConceptName('Breadth First Search')).toBe('breadth-first-search');
+      expect(slugifyConceptName('Machine Learning (ML)')).toBe('machine-learning-ml');
+      expect(slugifyConceptName('  Calculus II - Integration & Series! ')).toBe(
+        'calculus-ii-integration-series',
+      );
+      expect(slugifyConceptName('Feynman Technique')).toBe('feynman-technique');
+    });
+
+    it('handles multiple dashes and special punctuation cleanly', () => {
+      expect(slugifyConceptName('Object-Oriented --- Programming')).toBe(
+        'object-oriented-programming',
+      );
+      expect(slugifyConceptName('@#$%Hello World***')).toBe('hello-world');
+    });
+  });
+
+  describe('conceptExtractionSchema', () => {
+    it('validates a valid LLM extraction result', () => {
+      const payload = {
+        concepts: [
+          {
+            name: 'Linear Algebra',
+            pacerCategory: 'conceptual',
+            bloomLevel: 2,
+            aliases: ['Matrix Algebra'],
+          },
+          {
+            name: 'Matrix Multiplication',
+            pacerCategory: 'procedural',
+            bloomLevel: 3,
+            aliases: [],
+          },
+        ],
+        prerequisites: [
+          {
+            sourceName: 'Linear Algebra',
+            targetName: 'Matrix Multiplication',
+            relationshipType: 'prerequisite',
+            reasoning: 'Understanding vector spaces is necessary before performing operations',
+          },
+        ],
+      };
+
+      const parsed = conceptExtractionSchema.safeParse(payload);
+      expect(parsed.success).toBe(true);
+    });
+
+    it('rejects invalid PACER category or Bloom levels', () => {
+      const invalidPacer = {
+        concepts: [
+          {
+            name: 'Invalid PACER',
+            pacerCategory: 'random_category',
+            bloomLevel: 2,
+            aliases: [],
+          },
+        ],
+        prerequisites: [],
+      };
+      expect(conceptExtractionSchema.safeParse(invalidPacer).success).toBe(false);
+
+      const invalidBloom = {
+        concepts: [
+          {
+            name: 'Invalid Bloom',
+            pacerCategory: 'conceptual',
+            bloomLevel: 7, // Bloom is 1-6
+            aliases: [],
+          },
+        ],
+        prerequisites: [],
+      };
+      expect(conceptExtractionSchema.safeParse(invalidBloom).success).toBe(false);
+    });
+  });
+
+  describe('sanitizeExtractedGraph', () => {
+    it('drops self-loops where sourceName === targetName', () => {
+      const raw = {
+        concepts: [
+          {
+            name: 'Recursion',
+            pacerCategory: 'conceptual' as const,
+            bloomLevel: 3,
+            aliases: [],
+          },
+        ],
+        prerequisites: [
+          {
+            sourceName: 'Recursion',
+            targetName: 'Recursion',
+            relationshipType: 'prerequisite',
+            reasoning: 'Self loop',
+          },
+          {
+            sourceName: 'recursion',
+            targetName: 'Recursion',
+            relationshipType: 'prerequisite',
+            reasoning: 'Case insensitive self loop',
+          },
+        ],
+      };
+
+      const result = sanitizeExtractedGraph(raw);
+      expect(result.concepts).toHaveLength(1);
+      expect(result.prerequisites).toHaveLength(0);
+    });
+
+    it('drops dangling references targeting concepts not in vocabulary/batch', () => {
+      const raw = {
+        concepts: [
+          {
+            name: 'Binary Search Tree',
+            pacerCategory: 'procedural' as const,
+            bloomLevel: 3,
+            aliases: [],
+          },
+        ],
+        prerequisites: [
+          {
+            sourceName: 'Graph Theory', // Not in concepts vocabulary
+            targetName: 'Binary Search Tree',
+            relationshipType: 'prerequisite',
+            reasoning: 'Dangling source',
+          },
+          {
+            sourceName: 'Binary Search Tree',
+            targetName: 'Red Black Tree', // Not in concepts vocabulary
+            relationshipType: 'prerequisite',
+            reasoning: 'Dangling target',
+          },
+        ],
+      };
+
+      const result = sanitizeExtractedGraph(raw);
+      expect(result.concepts).toHaveLength(1);
+      expect(result.prerequisites).toHaveLength(0);
+    });
+
+    it('retains valid prerequisites matching vocabulary and attaches deterministic slugs', () => {
+      const raw = {
+        concepts: [
+          {
+            name: 'Linked List',
+            pacerCategory: 'conceptual' as const,
+            bloomLevel: 2,
+            aliases: ['Singly Linked List'],
+          },
+          {
+            name: 'Queue',
+            pacerCategory: 'procedural' as const,
+            bloomLevel: 3,
+            aliases: ['FIFO Queue'],
+          },
+        ],
+        prerequisites: [
+          {
+            sourceName: 'Linked List',
+            targetName: 'Queue',
+            relationshipType: 'prerequisite',
+            reasoning: 'Queues can be implemented using linked lists',
+          },
+        ],
+      };
+
+      const result = sanitizeExtractedGraph(raw);
+      expect(result.concepts).toHaveLength(2);
+      expect(result.concepts[0].slug).toBe('linked-list');
+      expect(result.concepts[1].slug).toBe('queue');
+      expect(result.prerequisites).toHaveLength(1);
+      expect(result.prerequisites[0].sourceSlug).toBe('linked-list');
+      expect(result.prerequisites[0].targetSlug).toBe('queue');
+    });
+
+    it('deduplicates concepts with identical slugs in the same batch', () => {
+      const raw = {
+        concepts: [
+          {
+            name: 'Dynamic Programming',
+            pacerCategory: 'conceptual' as const,
+            bloomLevel: 4,
+            aliases: ['DP'],
+          },
+          {
+            name: 'dynamic-programming',
+            pacerCategory: 'procedural' as const,
+            bloomLevel: 4,
+            aliases: ['Memoization'],
+          },
+        ],
+        prerequisites: [],
+      };
+
+      const result = sanitizeExtractedGraph(raw);
+      expect(result.concepts).toHaveLength(1);
+      expect(result.concepts[0].slug).toBe('dynamic-programming');
+      expect(result.concepts[0].aliases).toContain('DP');
+      expect(result.concepts[0].aliases).toContain('Memoization');
+    });
+  });
+
+  describe('sliceMaterialChunksIntoBatches', () => {
+    function createMockChunk(
+      index: number,
+      tokens: number,
+      content = '',
+      pageNumber = 1,
+    ): MaterialChunk {
+      return {
+        id: `chunk-${index}`,
+        materialId: 'mat-1',
+        projectId: 'proj-1',
+        userId: 'user-1',
+        chunkIndex: index,
+        content: content || `Sample content for chunk ${index}`,
+        tokenCount: tokens,
+        embedding: null,
+        metadata: { pageNumber },
+        createdAt: new Date(),
+      };
+    }
+
+    it('returns a single batch when total tokens is within batch limit (16k - 32k)', () => {
+      const chunks = [createMockChunk(0, 500), createMockChunk(1, 1000), createMockChunk(2, 2000)];
+
+      const batches = sliceMaterialChunksIntoBatches(chunks);
+      expect(batches).toHaveLength(1);
+      expect(batches[0].chunkIndices).toEqual([0, 1, 2]);
+      expect(batches[0].tokenCount).toBe(3500);
+      expect(batches[0].content).toContain('chunk 0');
+      expect(batches[0].content).toContain('chunk 2');
+    });
+
+    it('returns empty array when chunks array is empty', () => {
+      expect(sliceMaterialChunksIntoBatches([])).toEqual([]);
+    });
+
+    it('slices on heading boundaries (#, ##) once minimum batch token threshold is reached', () => {
+      // Chunk 0: 10,000 tokens
+      // Chunk 1: 7,000 tokens (accumulated = 17,000 tokens >= 16,000 min tokens)
+      // Chunk 2: Starts with "## Chapter 2", 5,000 tokens -> should start new batch!
+      const chunks = [
+        createMockChunk(0, 10000, 'Content part 1'),
+        createMockChunk(1, 7000, 'Content part 2'),
+        createMockChunk(2, 5000, '## Chapter 2: Advanced Topics\nContent part 3'),
+      ];
+
+      const batches = sliceMaterialChunksIntoBatches(chunks, {
+        minTokens: 16000,
+        maxTokens: 32000,
+      });
+
+      expect(batches).toHaveLength(2);
+      expect(batches[0].chunkIndices).toEqual([0, 1]);
+      expect(batches[0].tokenCount).toBe(17000);
+      expect(batches[1].chunkIndices).toEqual([2]);
+      expect(batches[1].tokenCount).toBe(5000);
+    });
+
+    it('slices on page boundaries when accumulated tokens >= minTokens and page changes', () => {
+      const chunks = [
+        createMockChunk(0, 10000, 'Page 1 text', 1),
+        createMockChunk(1, 6500, 'Page 1 continued', 1),
+        createMockChunk(2, 4000, 'Page 2 starting', 2),
+      ];
+
+      const batches = sliceMaterialChunksIntoBatches(chunks, {
+        minTokens: 16000,
+        maxTokens: 32000,
+      });
+
+      expect(batches).toHaveLength(2);
+      expect(batches[0].chunkIndices).toEqual([0, 1]);
+      expect(batches[1].chunkIndices).toEqual([2]);
+    });
+
+    it('splits when maxTokens threshold would be exceeded even without natural boundary', () => {
+      const chunks = [
+        createMockChunk(0, 20000, 'Chunk 0', 1),
+        createMockChunk(1, 15000, 'Chunk 1', 1), // 20k + 15k = 35k > 32k maxTokens
+      ];
+
+      const batches = sliceMaterialChunksIntoBatches(chunks, {
+        minTokens: 16000,
+        maxTokens: 32000,
+      });
+
+      expect(batches).toHaveLength(2);
+      expect(batches[0].chunkIndices).toEqual([0]);
+      expect(batches[1].chunkIndices).toEqual([1]);
+    });
+  });
+});

--- a/lib/materials/concept-extraction.test.ts
+++ b/lib/materials/concept-extraction.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { MaterialChunk } from '@/lib/db/schema';
 import {
   conceptExtractionSchema,
+  isMaterialExtractingGraph,
   linkExercisesToKcs,
   sanitizeExtractedGraph,
   sliceMaterialChunksIntoBatches,
@@ -571,6 +572,36 @@ describe('Concept Extraction Domain Logic', () => {
       expect(batches).toHaveLength(2);
       expect(batches[0].chunkIndices).toEqual([0]);
       expect(batches[1].chunkIndices).toEqual([1]);
+    });
+  });
+
+  describe('isMaterialExtractingGraph', () => {
+    it('returns true when metadata has status queued or extracting', () => {
+      expect(isMaterialExtractingGraph({ graphExtraction: { status: 'queued' } })).toBe(true);
+      expect(isMaterialExtractingGraph({ graphExtraction: { status: 'extracting' } })).toBe(true);
+      expect(isMaterialExtractingGraph({ graphExtraction: { status: 'ready' } })).toBe(false);
+      expect(isMaterialExtractingGraph({ graphExtraction: { status: 'failed' } })).toBe(false);
+      expect(isMaterialExtractingGraph({})).toBe(false);
+      expect(isMaterialExtractingGraph(null)).toBe(false);
+      expect(isMaterialExtractingGraph(undefined)).toBe(false);
+    });
+
+    it('returns true when passed material object containing metadata', () => {
+      expect(
+        isMaterialExtractingGraph({
+          id: 'mat-1',
+          status: 'ready',
+          metadata: { graphExtraction: { status: 'extracting' } },
+        }),
+      ).toBe(true);
+
+      expect(
+        isMaterialExtractingGraph({
+          id: 'mat-2',
+          status: 'ready',
+          metadata: { graphExtraction: { status: 'ready' } },
+        }),
+      ).toBe(false);
     });
   });
 });

--- a/lib/materials/concept-extraction.test.ts
+++ b/lib/materials/concept-extraction.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { MaterialChunk } from '@/lib/db/schema';
 import {
   conceptExtractionSchema,
+  linkExercisesToKcs,
   sanitizeExtractedGraph,
   sliceMaterialChunksIntoBatches,
   slugifyConceptName,
@@ -83,6 +84,103 @@ describe('Concept Extraction Domain Logic', () => {
         prerequisites: [],
       };
       expect(conceptExtractionSchema.safeParse(invalidBloom).success).toBe(false);
+    });
+
+    it('defaults exercises to empty array if omitted', () => {
+      const payload = {
+        concepts: [
+          {
+            name: 'Calculus',
+            pacerCategory: 'conceptual',
+            bloomLevel: 2,
+            aliases: [],
+          },
+        ],
+        prerequisites: [],
+      };
+      const parsed = conceptExtractionSchema.safeParse(payload);
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data.exercises).toEqual([]);
+      }
+    });
+
+    it('validates exercises with proper types, difficulty range, and question types', () => {
+      const payload = {
+        concepts: [
+          {
+            name: 'Derivatives',
+            pacerCategory: 'conceptual',
+            bloomLevel: 3,
+            aliases: [],
+          },
+        ],
+        prerequisites: [],
+        exercises: [
+          {
+            pageNumber: 12,
+            title: 'Problem 2.4',
+            prompt: 'Find the derivative of f(x) = x^2',
+            solution: '2x',
+            questionType: 'calculation',
+            difficulty: 2,
+            targetConceptName: 'Derivatives',
+          },
+          {
+            pageNumber: 13,
+            questionType: 'multiple_choice',
+            targetConceptName: 'Derivatives',
+          },
+          {
+            pageNumber: 14,
+            title: 'Problem 2.5',
+            prompt: 'Unsolved challenge problem',
+            solution: null,
+            questionType: 'conceptual',
+            difficulty: 4,
+            targetConceptName: 'Derivatives',
+          },
+        ],
+      };
+
+      const parsed = conceptExtractionSchema.safeParse(payload);
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data.exercises).toHaveLength(3);
+        expect(parsed.data.exercises[0].difficulty).toBe(2);
+        expect(parsed.data.exercises[1].difficulty).toBe(1); // default difficulty
+        expect(parsed.data.exercises[1].solution).toBeUndefined();
+        expect(parsed.data.exercises[2].solution).toBeNull();
+      }
+    });
+
+    it('rejects invalid questionType or out-of-range difficulty in exercises', () => {
+      const invalidQuestionType = {
+        concepts: [],
+        prerequisites: [],
+        exercises: [
+          {
+            pageNumber: 5,
+            questionType: 'invalid_type',
+            targetConceptName: 'Math',
+          },
+        ],
+      };
+      expect(conceptExtractionSchema.safeParse(invalidQuestionType).success).toBe(false);
+
+      const invalidDifficulty = {
+        concepts: [],
+        prerequisites: [],
+        exercises: [
+          {
+            pageNumber: 5,
+            questionType: 'conceptual',
+            difficulty: 6, // 1 to 5 only
+            targetConceptName: 'Math',
+          },
+        ],
+      };
+      expect(conceptExtractionSchema.safeParse(invalidDifficulty).success).toBe(false);
     });
   });
 
@@ -208,6 +306,179 @@ describe('Concept Extraction Domain Logic', () => {
       expect(result.concepts[0].slug).toBe('dynamic-programming');
       expect(result.concepts[0].aliases).toContain('DP');
       expect(result.concepts[0].aliases).toContain('Memoization');
+    });
+    it('sanitizes extracted exercises and slugifies targetConceptName', () => {
+      const raw = {
+        concepts: [
+          {
+            name: 'Depth First Search',
+            pacerCategory: 'procedural' as const,
+            bloomLevel: 3,
+            aliases: ['DFS'],
+          },
+        ],
+        prerequisites: [],
+        exercises: [
+          {
+            pageNumber: 15,
+            title: '  Problem 4.1  ',
+            prompt: ' Trace DFS on the given tree:  ',
+            solution: ' A -> B -> C ',
+            questionType: 'calculation' as const,
+            difficulty: 3,
+            targetConceptName: ' Depth First Search ',
+          },
+        ],
+      };
+
+      const result = sanitizeExtractedGraph(raw);
+      expect(result.exercises).toHaveLength(1);
+      expect(result.exercises[0]).toEqual({
+        pageNumber: 15,
+        title: 'Problem 4.1',
+        prompt: 'Trace DFS on the given tree:',
+        solution: 'A -> B -> C',
+        questionType: 'calculation',
+        difficulty: 3,
+        targetConceptName: 'Depth First Search',
+        targetConceptSlug: 'depth-first-search',
+      });
+    });
+  });
+
+  describe('linkExercisesToKcs', () => {
+    it('links exercises to matching KC from active batch or existing project KCs and maps foreign keys', () => {
+      const sanitizedExercises = [
+        {
+          pageNumber: 5,
+          title: 'Ex 1',
+          prompt: 'What is a stack?',
+          solution: 'LIFO structure',
+          questionType: 'conceptual' as const,
+          difficulty: 1,
+          targetConceptName: 'Stack Data Structure',
+          targetConceptSlug: 'stack-data-structure',
+        },
+        {
+          pageNumber: 8,
+          title: 'Ex 2',
+          prompt: 'Implement DFS',
+          solution: undefined,
+          questionType: 'code' as const,
+          difficulty: 4,
+          targetConceptName: 'Depth First Search',
+          targetConceptSlug: 'depth-first-search',
+        },
+      ];
+
+      const availableKcs = [
+        { id: 'kc-uuid-1', slug: 'stack-data-structure', name: 'Stack Data Structure' },
+        { id: 'kc-uuid-2', slug: 'depth-first-search', name: 'Depth First Search' },
+      ];
+
+      const linked = linkExercisesToKcs({
+        exercises: sanitizedExercises,
+        availableKcs,
+        projectId: 'proj-1',
+        userId: 'user-1',
+        materialId: 'mat-1',
+      });
+
+      expect(linked).toHaveLength(2);
+      expect(linked[0]).toEqual({
+        projectId: 'proj-1',
+        userId: 'user-1',
+        materialId: 'mat-1',
+        kcId: 'kc-uuid-1',
+        pageNumber: 5,
+        title: 'Ex 1',
+        prompt: 'What is a stack?',
+        solution: 'LIFO structure',
+        questionType: 'conceptual',
+        difficulty: 1,
+      });
+      expect(linked[1]).toEqual({
+        projectId: 'proj-1',
+        userId: 'user-1',
+        materialId: 'mat-1',
+        kcId: 'kc-uuid-2',
+        pageNumber: 8,
+        title: 'Ex 2',
+        prompt: 'Implement DFS',
+        solution: null,
+        questionType: 'code',
+        difficulty: 4,
+      });
+    });
+
+    it('discards dangling exercises where target concept cannot be resolved', () => {
+      const sanitizedExercises = [
+        {
+          pageNumber: 10,
+          title: 'Valid Ex',
+          prompt: 'Valid prompt',
+          questionType: 'multiple_choice' as const,
+          difficulty: 2,
+          targetConceptName: 'Known Concept',
+          targetConceptSlug: 'known-concept',
+        },
+        {
+          pageNumber: 12,
+          title: 'Dangling Ex',
+          prompt: 'Dangling prompt',
+          questionType: 'multiple_choice' as const,
+          difficulty: 2,
+          targetConceptName: 'Unknown Concept',
+          targetConceptSlug: 'unknown-concept',
+        },
+      ];
+
+      const availableKcs = [{ id: 'kc-uuid-1', slug: 'known-concept', name: 'Known Concept' }];
+
+      const linked = linkExercisesToKcs({
+        exercises: sanitizedExercises,
+        availableKcs,
+        projectId: 'proj-1',
+        userId: 'user-1',
+        materialId: 'mat-1',
+      });
+
+      expect(linked).toHaveLength(1);
+      expect(linked[0].title).toBe('Valid Ex');
+      expect(linked[0].kcId).toBe('kc-uuid-1');
+    });
+
+    it('resolves by case-insensitive name matching if slug does not match exactly', () => {
+      const sanitizedExercises = [
+        {
+          pageNumber: 20,
+          title: 'Name Match Ex',
+          prompt: 'Solve problem',
+          questionType: 'calculation' as const,
+          difficulty: 3,
+          targetConceptName: 'Dynamic Programming',
+          targetConceptSlug: 'dynamic-programming',
+        },
+      ];
+
+      const availableKcs = [
+        {
+          id: 'kc-uuid-3',
+          slug: 'custom-dp-slug',
+          name: 'dynamic programming',
+        },
+      ];
+
+      const linked = linkExercisesToKcs({
+        exercises: sanitizedExercises,
+        availableKcs,
+        projectId: 'proj-1',
+        userId: 'user-1',
+        materialId: 'mat-1',
+      });
+
+      expect(linked).toHaveLength(1);
+      expect(linked[0].kcId).toBe('kc-uuid-3');
     });
   });
 

--- a/lib/materials/concept-extraction.ts
+++ b/lib/materials/concept-extraction.ts
@@ -10,7 +10,7 @@ import {
 } from '@/lib/db/schema/knowledge';
 import { ChatbotError } from '@/lib/errors';
 import { sendConceptGraphExtractJob } from '@/lib/queue/boss';
-import type { MaterialGraphExtractionMetadata } from './types';
+import type { MaterialGraphExtractionMetadata, MaterialMetadata } from './types';
 
 export function slugifyConceptName(name: string): string {
   return name
@@ -374,9 +374,22 @@ export function updateMaterialGraphExtractionMetadata(
   };
 }
 
-export function isMaterialExtractingGraph(metadata?: Record<string, unknown> | null): boolean {
-  const graphExtraction = metadata?.graphExtraction as MaterialGraphExtractionMetadata | undefined;
-  return graphExtraction?.status === 'queued' || graphExtraction?.status === 'extracting';
+export type MaterialWithMetadata = {
+  metadata?: MaterialMetadata | Record<string, unknown> | null;
+};
+
+export function isMaterialExtractingGraph(
+  materialOrMetadata?: MaterialWithMetadata | MaterialMetadata | Record<string, unknown> | null,
+): boolean {
+  if (!materialOrMetadata) return false;
+  const metadata =
+    'metadata' in materialOrMetadata &&
+    materialOrMetadata.metadata !== null &&
+    typeof materialOrMetadata.metadata === 'object'
+      ? (materialOrMetadata.metadata as MaterialMetadata)
+      : (materialOrMetadata as MaterialMetadata);
+  const status = metadata?.graphExtraction?.status;
+  return status === 'queued' || status === 'extracting';
 }
 
 export type QueueGraphExtractionParams = {
@@ -388,7 +401,7 @@ export type QueueGraphExtractionParams = {
 export type QueueGraphExtractionResult = {
   enqueued: boolean;
   materialCount: number;
-  jobId: string;
+  jobId: string | null;
 };
 
 export async function queueGraphExtraction({
@@ -431,7 +444,12 @@ export async function queueGraphExtraction({
   });
 
   if (!jobId) {
-    throw new ChatbotError('bad_request:api', 'Failed to queue graph extraction job.');
+    // Debounced by pg-boss singletonKey because an extraction job for this project is already active or queued
+    return {
+      enqueued: false,
+      materialCount: targetIds.length,
+      jobId: null,
+    };
   }
 
   const projectMaterialMap = new Map(projectMaterials.map((m) => [m.id, m]));

--- a/lib/materials/concept-extraction.ts
+++ b/lib/materials/concept-extraction.ts
@@ -1,0 +1,323 @@
+import { z } from 'zod';
+import { getMaterialsByProjectId, updateMaterialStatus } from '@/lib/db/queries/material';
+import type { MaterialChunk } from '@/lib/db/schema';
+import { PACER_CATEGORIES, type PacerCategory } from '@/lib/db/schema/knowledge';
+import { ChatbotError } from '@/lib/errors';
+import { sendConceptGraphExtractJob } from '@/lib/queue/boss';
+import type { MaterialGraphExtractionMetadata } from './types';
+
+export function slugifyConceptName(name: string): string {
+  return name
+    .toLowerCase()
+    .trim()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '') // remove diacritics
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export const conceptExtractionSchema = z.object({
+  concepts: z.array(
+    z.object({
+      name: z.string().trim().min(1, 'Concept name is required'),
+      pacerCategory: z.enum(PACER_CATEGORIES, {
+        message:
+          "PACER category must be one of: 'procedural', 'analogous', 'conceptual', 'evidence', 'reference'",
+      }),
+      bloomLevel: z
+        .number()
+        .int()
+        .min(1, 'Bloom level must be at least 1')
+        .max(6, 'Bloom level cannot exceed 6'),
+      aliases: z.array(z.string().trim()).default([]),
+    }),
+  ),
+  prerequisites: z.array(
+    z.object({
+      sourceName: z.string().trim().min(1, 'Prerequisite source concept name is required'),
+      targetName: z.string().trim().min(1, 'Prerequisite target concept name is required'),
+      relationshipType: z.string().trim().default('prerequisite'),
+      reasoning: z.string().trim().optional(),
+    }),
+  ),
+});
+
+export type RawConcept = z.infer<typeof conceptExtractionSchema>['concepts'][number];
+export type RawPrerequisite = z.infer<typeof conceptExtractionSchema>['prerequisites'][number];
+export type RawExtractionResult = z.infer<typeof conceptExtractionSchema>;
+
+export type SanitizedConcept = {
+  name: string;
+  slug: string;
+  pacerCategory: PacerCategory;
+  bloomLevel: number;
+  aliases: string[];
+};
+
+export type SanitizedPrerequisite = {
+  sourceName: string;
+  targetName: string;
+  sourceSlug: string;
+  targetSlug: string;
+  relationshipType: string;
+  reasoning?: string;
+};
+
+export type SanitizedExtractionResult = {
+  concepts: SanitizedConcept[];
+  prerequisites: SanitizedPrerequisite[];
+};
+
+function sanitizeConcepts(rawConcepts: RawConcept[]): SanitizedConcept[] {
+  const conceptMapBySlug = new Map<string, SanitizedConcept>();
+
+  for (const c of rawConcepts) {
+    const slug = slugifyConceptName(c.name);
+    if (!slug) continue;
+
+    const existing = conceptMapBySlug.get(slug);
+    if (existing) {
+      existing.aliases = Array.from(new Set([...existing.aliases, ...c.aliases]));
+    } else {
+      conceptMapBySlug.set(slug, {
+        name: c.name.trim(),
+        slug,
+        pacerCategory: c.pacerCategory,
+        bloomLevel: c.bloomLevel,
+        aliases: [...new Set(c.aliases.map((a) => a.trim()).filter(Boolean))],
+      });
+    }
+  }
+
+  return Array.from(conceptMapBySlug.values());
+}
+
+function sanitizePrerequisites(
+  rawPrerequisites: RawPrerequisite[],
+  validSlugs: Set<string>,
+): SanitizedPrerequisite[] {
+  const validPrerequisites: SanitizedPrerequisite[] = [];
+  const seenPrereqKeys = new Set<string>();
+
+  for (const p of rawPrerequisites) {
+    const sourceSlug = slugifyConceptName(p.sourceName);
+    const targetSlug = slugifyConceptName(p.targetName);
+
+    if (!sourceSlug || !targetSlug || sourceSlug === targetSlug) {
+      continue;
+    }
+
+    if (!validSlugs.has(sourceSlug) || !validSlugs.has(targetSlug)) {
+      continue;
+    }
+
+    const relationshipType = p.relationshipType || 'prerequisite';
+    const key = `${sourceSlug}->${targetSlug}:${relationshipType}`;
+
+    if (seenPrereqKeys.has(key)) {
+      continue;
+    }
+
+    seenPrereqKeys.add(key);
+    validPrerequisites.push({
+      sourceName: p.sourceName.trim(),
+      targetName: p.targetName.trim(),
+      sourceSlug,
+      targetSlug,
+      relationshipType,
+      reasoning: p.reasoning?.trim(),
+    });
+  }
+
+  return validPrerequisites;
+}
+
+export function sanitizeExtractedGraph(raw: RawExtractionResult): SanitizedExtractionResult {
+  const concepts = sanitizeConcepts(raw.concepts);
+  const validSlugs = new Set(concepts.map((c) => c.slug));
+  const prerequisites = sanitizePrerequisites(raw.prerequisites, validSlugs);
+
+  return {
+    concepts,
+    prerequisites,
+  };
+}
+
+export type BatchOptions = {
+  minTokens?: number;
+  maxTokens?: number;
+};
+
+export type ContentBatch = {
+  batchIndex: number;
+  content: string;
+  tokenCount: number;
+  chunkIndices: number[];
+};
+
+export function sliceMaterialChunksIntoBatches(
+  chunks: MaterialChunk[],
+  options: BatchOptions = {},
+): ContentBatch[] {
+  if (!chunks || chunks.length === 0) {
+    return [];
+  }
+
+  const { minTokens = 16000, maxTokens = 32000 } = options;
+
+  const sortedChunks = [...chunks].sort((a, b) => a.chunkIndex - b.chunkIndex);
+  const batches: ContentBatch[] = [];
+
+  let currentBatchChunks: MaterialChunk[] = [];
+  let currentBatchTokens = 0;
+  let previousPageNumber: number | undefined;
+
+  for (const chunk of sortedChunks) {
+    const chunkTokens = chunk.tokenCount || Math.ceil(chunk.content.length / 4);
+    const chunkPage =
+      typeof chunk.metadata === 'object' &&
+      chunk.metadata !== null &&
+      'pageNumber' in chunk.metadata
+        ? (chunk.metadata.pageNumber as number | undefined)
+        : undefined;
+
+    const startsWithMajorHeading = /^(?:#{1,2}\s+)/m.test(chunk.content.trim());
+    const isPageChange =
+      previousPageNumber !== undefined &&
+      chunkPage !== undefined &&
+      chunkPage !== previousPageNumber;
+
+    const hasReachedMin = currentBatchTokens >= minTokens;
+    const isNaturalBoundary = startsWithMajorHeading || isPageChange;
+    const wouldExceedMax = currentBatchTokens + chunkTokens > maxTokens;
+
+    if (currentBatchChunks.length > 0 && ((hasReachedMin && isNaturalBoundary) || wouldExceedMax)) {
+      batches.push(createContentBatch(currentBatchChunks, batches.length, currentBatchTokens));
+      currentBatchChunks = [];
+      currentBatchTokens = 0;
+    }
+
+    currentBatchChunks.push(chunk);
+    currentBatchTokens += chunkTokens;
+    previousPageNumber = chunkPage;
+  }
+
+  if (currentBatchChunks.length > 0) {
+    batches.push(createContentBatch(currentBatchChunks, batches.length, currentBatchTokens));
+  }
+
+  return batches;
+}
+
+function createContentBatch(
+  chunks: MaterialChunk[],
+  batchIndex: number,
+  tokenCount: number,
+): ContentBatch {
+  return {
+    batchIndex,
+    content: chunks.map((c) => c.content).join('\n\n'),
+    tokenCount,
+    chunkIndices: chunks.map((c) => c.chunkIndex),
+  };
+}
+
+export function updateMaterialGraphExtractionMetadata(
+  currentMetadata: Record<string, unknown> | null | undefined,
+  update: Partial<MaterialGraphExtractionMetadata>,
+): Record<string, unknown> {
+  const base = (currentMetadata ?? {}) as Record<string, unknown>;
+  const graphExtraction = (base.graphExtraction ?? {}) as Record<string, unknown>;
+
+  return {
+    ...base,
+    graphExtraction: {
+      ...graphExtraction,
+      ...update,
+    },
+  };
+}
+
+export function isMaterialExtractingGraph(metadata?: Record<string, unknown> | null): boolean {
+  const graphExtraction = metadata?.graphExtraction as MaterialGraphExtractionMetadata | undefined;
+  return graphExtraction?.status === 'queued' || graphExtraction?.status === 'extracting';
+}
+
+export type QueueGraphExtractionParams = {
+  projectId: string;
+  userId: string;
+  materialIds?: string[];
+};
+
+export type QueueGraphExtractionResult = {
+  enqueued: boolean;
+  materialCount: number;
+  jobId: string;
+};
+
+export async function queueGraphExtraction({
+  projectId,
+  userId,
+  materialIds,
+}: QueueGraphExtractionParams): Promise<QueueGraphExtractionResult> {
+  const projectMaterials = await getMaterialsByProjectId({
+    projectId,
+    userId,
+  });
+
+  let targetIds: string[];
+
+  if (materialIds && materialIds.length > 0) {
+    const projectMaterialMap = new Map(projectMaterials.map((m) => [m.id, m]));
+    targetIds = materialIds.filter((id) => projectMaterialMap.has(id));
+
+    if (targetIds.length === 0) {
+      throw new ChatbotError(
+        'bad_request:api',
+        'None of the specified materials belong to this project.',
+      );
+    }
+  } else {
+    targetIds = projectMaterials.filter((m) => m.status === 'ready').map((m) => m.id);
+
+    if (targetIds.length === 0) {
+      throw new ChatbotError(
+        'bad_request:api',
+        'No ready materials available in this project for extraction.',
+      );
+    }
+  }
+
+  const jobId = await sendConceptGraphExtractJob({
+    projectId,
+    userId,
+    materialIds: targetIds,
+  });
+
+  if (!jobId) {
+    throw new ChatbotError('bad_request:api', 'Failed to queue graph extraction job.');
+  }
+
+  const projectMaterialMap = new Map(projectMaterials.map((m) => [m.id, m]));
+  for (const materialId of targetIds) {
+    const material = projectMaterialMap.get(materialId);
+    if (!material) continue;
+
+    const metadata = updateMaterialGraphExtractionMetadata(
+      material.metadata as Record<string, unknown>,
+      { status: 'queued', jobId },
+    );
+
+    await updateMaterialStatus({
+      id: materialId,
+      status: material.status,
+      metadata,
+    });
+  }
+
+  return {
+    enqueued: true,
+    materialCount: targetIds.length,
+    jobId,
+  };
+}

--- a/lib/materials/concept-extraction.ts
+++ b/lib/materials/concept-extraction.ts
@@ -10,7 +10,7 @@ import {
 } from '@/lib/db/schema/knowledge';
 import { ChatbotError } from '@/lib/errors';
 import { sendConceptGraphExtractJob } from '@/lib/queue/boss';
-import type { MaterialGraphExtractionMetadata, MaterialMetadata } from './types';
+import type { MaterialGraphExtractionMetadata } from './types';
 
 export function slugifyConceptName(name: string): string {
   return name
@@ -374,23 +374,10 @@ export function updateMaterialGraphExtractionMetadata(
   };
 }
 
-export type MaterialWithMetadata = {
-  metadata?: MaterialMetadata | Record<string, unknown> | null;
-};
-
-export function isMaterialExtractingGraph(
-  materialOrMetadata?: MaterialWithMetadata | MaterialMetadata | Record<string, unknown> | null,
-): boolean {
-  if (!materialOrMetadata) return false;
-  const metadata =
-    'metadata' in materialOrMetadata &&
-    materialOrMetadata.metadata !== null &&
-    typeof materialOrMetadata.metadata === 'object'
-      ? (materialOrMetadata.metadata as MaterialMetadata)
-      : (materialOrMetadata as MaterialMetadata);
-  const status = metadata?.graphExtraction?.status;
-  return status === 'queued' || status === 'extracting';
-}
+export {
+  isMaterialExtractingGraph,
+  type MaterialWithMetadata,
+} from './types';
 
 export type QueueGraphExtractionParams = {
   projectId: string;

--- a/lib/materials/concept-extraction.ts
+++ b/lib/materials/concept-extraction.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { getMaterialsByProjectId, updateMaterialStatus } from '@/lib/db/queries/material';
 import type { MaterialChunk } from '@/lib/db/schema';
-import { PACER_CATEGORIES, type PacerCategory } from '@/lib/db/schema/knowledge';
+import {
+  EXERCISE_QUESTION_TYPES,
+  type ExerciseQuestionType,
+  type NewExercise,
+  PACER_CATEGORIES,
+  type PacerCategory,
+} from '@/lib/db/schema/knowledge';
 import { ChatbotError } from '@/lib/errors';
 import { sendConceptGraphExtractJob } from '@/lib/queue/boss';
 import type { MaterialGraphExtractionMetadata } from './types';
@@ -15,6 +21,23 @@ export function slugifyConceptName(name: string): string {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
 }
+
+export const exerciseExtractionSchema = z.object({
+  pageNumber: z.number().int().describe('Page number in source material where exercise appears'),
+  title: z.string().optional().describe('Label or title, e.g. "Problem 3.1"'),
+  prompt: z
+    .string()
+    .optional()
+    .describe('Text/LaTeX transcription of problem statement if applicable'),
+  solution: z
+    .string()
+    .nullable()
+    .optional()
+    .describe('Answer or solution if explicitly stated in text; omit if unsolved'),
+  questionType: z.enum(EXERCISE_QUESTION_TYPES),
+  difficulty: z.number().int().min(1).max(5).default(1),
+  targetConceptName: z.string().describe('Concept name that this exercise primarily tests'),
+});
 
 export const conceptExtractionSchema = z.object({
   concepts: z.array(
@@ -40,10 +63,12 @@ export const conceptExtractionSchema = z.object({
       reasoning: z.string().trim().optional(),
     }),
   ),
+  exercises: z.array(exerciseExtractionSchema).default([]),
 });
 
 export type RawConcept = z.infer<typeof conceptExtractionSchema>['concepts'][number];
 export type RawPrerequisite = z.infer<typeof conceptExtractionSchema>['prerequisites'][number];
+export type RawExercise = z.infer<typeof conceptExtractionSchema>['exercises'][number];
 export type RawExtractionResult = z.infer<typeof conceptExtractionSchema>;
 
 export type SanitizedConcept = {
@@ -63,9 +88,21 @@ export type SanitizedPrerequisite = {
   reasoning?: string;
 };
 
+export type SanitizedExercise = {
+  pageNumber: number;
+  title?: string;
+  prompt?: string;
+  solution?: string | null;
+  questionType: ExerciseQuestionType;
+  difficulty: number;
+  targetConceptName: string;
+  targetConceptSlug: string;
+};
+
 export type SanitizedExtractionResult = {
   concepts: SanitizedConcept[];
   prerequisites: SanitizedPrerequisite[];
+  exercises: SanitizedExercise[];
 };
 
 function sanitizeConcepts(rawConcepts: RawConcept[]): SanitizedConcept[] {
@@ -132,15 +169,114 @@ function sanitizePrerequisites(
   return validPrerequisites;
 }
 
-export function sanitizeExtractedGraph(raw: RawExtractionResult): SanitizedExtractionResult {
+function sanitizeExercises(rawExercises: RawExercise[] = []): SanitizedExercise[] {
+  const validExercises: SanitizedExercise[] = [];
+
+  for (const e of rawExercises) {
+    const targetConceptName = e.targetConceptName?.trim();
+    if (!targetConceptName) continue;
+    const targetConceptSlug = slugifyConceptName(targetConceptName);
+    if (!targetConceptSlug) continue;
+
+    const solution =
+      e.solution === null
+        ? null
+        : typeof e.solution === 'string' && e.solution.trim().length > 0
+          ? e.solution.trim()
+          : null;
+
+    validExercises.push({
+      pageNumber: e.pageNumber,
+      title: e.title?.trim() || undefined,
+      prompt: e.prompt?.trim() || undefined,
+      solution,
+      questionType: e.questionType,
+      difficulty: e.difficulty ?? 1,
+      targetConceptName,
+      targetConceptSlug,
+    });
+  }
+
+  return validExercises;
+}
+
+export function sanitizeExtractedGraph(raw: {
+  concepts: RawConcept[];
+  prerequisites: RawPrerequisite[];
+  exercises?: RawExercise[];
+}): SanitizedExtractionResult {
   const concepts = sanitizeConcepts(raw.concepts);
   const validSlugs = new Set(concepts.map((c) => c.slug));
   const prerequisites = sanitizePrerequisites(raw.prerequisites, validSlugs);
+  const exercises = sanitizeExercises(raw.exercises ?? []);
 
   return {
     concepts,
     prerequisites,
+    exercises,
   };
+}
+
+export type KcIdentifier = {
+  id: string;
+  name: string;
+  slug: string;
+};
+
+export type LinkExercisesToKcsParams = {
+  exercises: SanitizedExercise[];
+  availableKcs: KcIdentifier[];
+  projectId: string;
+  userId: string;
+  materialId: string;
+};
+
+export function linkExercisesToKcs({
+  exercises,
+  availableKcs,
+  projectId,
+  userId,
+  materialId,
+}: LinkExercisesToKcsParams): NewExercise[] {
+  if (!exercises || exercises.length === 0 || !availableKcs || availableKcs.length === 0) {
+    return [];
+  }
+
+  const kcBySlug = new Map<string, string>();
+  const kcByName = new Map<string, string>();
+
+  for (const kc of availableKcs) {
+    kcBySlug.set(kc.slug, kc.id);
+    kcByName.set(kc.name.trim().toLowerCase(), kc.id);
+  }
+
+  const linkedExercises: NewExercise[] = [];
+
+  for (const ex of exercises) {
+    const kcId =
+      kcBySlug.get(ex.targetConceptSlug) ??
+      kcBySlug.get(slugifyConceptName(ex.targetConceptName)) ??
+      kcByName.get(ex.targetConceptName.trim().toLowerCase());
+
+    if (!kcId) {
+      continue;
+    }
+
+    linkedExercises.push({
+      projectId,
+      userId,
+      materialId,
+      kcId,
+      pageNumber: ex.pageNumber,
+      title: ex.title,
+      prompt: ex.prompt,
+      solution: ex.solution ?? null,
+      questionType: ex.questionType,
+      difficulty: ex.difficulty,
+    });
+  }
+
+  return linkedExercises;
 }
 
 export type BatchOptions = {

--- a/lib/materials/index.ts
+++ b/lib/materials/index.ts
@@ -1,10 +1,13 @@
 export * from './chunker';
+export * from './concept-extraction';
 export * from './deletion';
+
 export * from './ingestion';
 export * from './inspection';
 export * from './intake';
 export * from './purge';
 export * from './rasterizer';
 export * from './retrieval';
+export * from './types';
 export * from './validation';
 export * from './vision';

--- a/lib/materials/types.ts
+++ b/lib/materials/types.ts
@@ -1,0 +1,42 @@
+export const GRAPH_EXTRACTION_STATUSES = [
+  'not_started',
+  'queued',
+  'extracting',
+  'ready',
+  'ready_with_warnings',
+  'failed',
+] as const;
+
+export type GraphExtractionStatus = (typeof GRAPH_EXTRACTION_STATUSES)[number];
+
+export type MaterialGraphExtractionMetadata = {
+  status: GraphExtractionStatus;
+  jobId?: string;
+  kcCount?: number;
+  exerciseCount?: number;
+  warnings?: string[];
+  error?: string;
+  startedAt?: string;
+  completedAt?: string;
+};
+
+export type MaterialMetadata = {
+  pageCount?: number;
+  chunkCount?: number;
+  tokenCount?: number;
+  progress?: {
+    stage?: string;
+    stagePercent?: number;
+    totalPages?: number;
+    currentPage?: number;
+    completedPages?: number;
+  };
+  graphExtraction?: MaterialGraphExtractionMetadata;
+  error?: {
+    message?: string;
+    stage?: string;
+    failedAt?: string;
+  };
+  processedAt?: string;
+  [key: string]: unknown;
+};

--- a/lib/materials/types.ts
+++ b/lib/materials/types.ts
@@ -40,3 +40,21 @@ export type MaterialMetadata = {
   processedAt?: string;
   [key: string]: unknown;
 };
+
+export type MaterialWithMetadata = {
+  metadata?: MaterialMetadata | Record<string, unknown> | null;
+};
+
+export function isMaterialExtractingGraph(
+  materialOrMetadata?: MaterialWithMetadata | MaterialMetadata | Record<string, unknown> | null,
+): boolean {
+  if (!materialOrMetadata) return false;
+  const metadata =
+    'metadata' in materialOrMetadata &&
+    materialOrMetadata.metadata !== null &&
+    typeof materialOrMetadata.metadata === 'object'
+      ? (materialOrMetadata.metadata as MaterialMetadata)
+      : (materialOrMetadata as MaterialMetadata);
+  const status = metadata?.graphExtraction?.status;
+  return status === 'queued' || status === 'extracting';
+}

--- a/lib/queue/boss.test.ts
+++ b/lib/queue/boss.test.ts
@@ -134,4 +134,21 @@ describe('pg-boss queue lifecycle', () => {
       },
     );
   });
+
+  it('sendConceptGraphExtractJob returns null when debounced by singletonKey', async () => {
+    mockStart.mockResolvedValueOnce(undefined);
+    mockCreateQueue.mockResolvedValue(undefined);
+    // pg-boss returns null when a job with matching singletonKey is active/queued
+    mockSend.mockResolvedValueOnce(null);
+
+    const { sendConceptGraphExtractJob } = await import('./boss');
+
+    const jobId = await sendConceptGraphExtractJob({
+      projectId: 'proj-duplicate',
+      userId: 'user-456',
+      materialIds: ['mat-1'],
+    });
+
+    expect(jobId).toBeNull();
+  });
 });

--- a/lib/queue/boss.test.ts
+++ b/lib/queue/boss.test.ts
@@ -103,4 +103,35 @@ describe('pg-boss queue lifecycle', () => {
 
     expect(jobId).toBeNull();
   });
+
+  it('sendConceptGraphExtractJob dispatches with singletonKey, retryLimit: 2, retryDelay: 15, and retryBackoff: true', async () => {
+    mockStart.mockResolvedValueOnce(undefined);
+    mockCreateQueue.mockResolvedValue(undefined);
+    mockSend.mockResolvedValueOnce('extract-job-999');
+
+    const { CONCEPT_GRAPH_EXTRACT_QUEUE, sendConceptGraphExtractJob } = await import('./boss');
+
+    const jobId = await sendConceptGraphExtractJob({
+      projectId: 'proj-123',
+      userId: 'user-456',
+      materialIds: ['mat-789'],
+    });
+
+    expect(jobId).toBe('extract-job-999');
+    expect(mockCreateQueue).toHaveBeenCalledWith(CONCEPT_GRAPH_EXTRACT_QUEUE);
+    expect(mockSend).toHaveBeenCalledWith(
+      CONCEPT_GRAPH_EXTRACT_QUEUE,
+      {
+        projectId: 'proj-123',
+        userId: 'user-456',
+        materialIds: ['mat-789'],
+      },
+      {
+        singletonKey: 'project:proj-123',
+        retryLimit: 2,
+        retryDelay: 15,
+        retryBackoff: true,
+      },
+    );
+  });
 });

--- a/lib/queue/boss.ts
+++ b/lib/queue/boss.ts
@@ -1,6 +1,7 @@
 import { PgBoss } from 'pg-boss';
 
 export const MATERIAL_INGEST_QUEUE = 'material-ingest';
+export const CONCEPT_GRAPH_EXTRACT_QUEUE = 'concept-graph-extract';
 
 export type MaterialIngestJobData = {
   materialId: string;
@@ -8,6 +9,12 @@ export type MaterialIngestJobData = {
   userId: string;
   storagePath: string;
   fileType: string;
+};
+
+export type ConceptGraphExtractJobData = {
+  projectId: string;
+  userId: string;
+  materialIds: string[];
 };
 
 let bossInstance: PgBoss | null = null;
@@ -42,6 +49,7 @@ export async function startQueue(): Promise<PgBoss | null> {
   startPromise = (async () => {
     await boss.start();
     await boss.createQueue(MATERIAL_INGEST_QUEUE);
+    await boss.createQueue(CONCEPT_GRAPH_EXTRACT_QUEUE);
     return boss;
   })().catch((error) => {
     console.error('Failed to start pg-boss queue:', error);
@@ -78,6 +86,27 @@ export async function sendIngestJob(data: MaterialIngestJobData): Promise<string
   } catch (error) {
     console.error('Failed to dispatch material ingest job:', error);
     // In test environments or when pg-boss fails, fallback
+    return null;
+  }
+}
+
+export async function sendConceptGraphExtractJob(
+  data: ConceptGraphExtractJobData,
+): Promise<string | null> {
+  try {
+    const boss = await startQueue();
+    if (!boss) {
+      throw new Error('pg-boss queue is not available');
+    }
+    const jobId = await boss.send(CONCEPT_GRAPH_EXTRACT_QUEUE, data, {
+      singletonKey: `project:${data.projectId}`,
+      retryLimit: 2,
+      retryDelay: 15,
+      retryBackoff: true,
+    });
+    return jobId;
+  } catch (error) {
+    console.error('Failed to dispatch concept graph extract job:', error);
     return null;
   }
 }

--- a/lib/queue/index.ts
+++ b/lib/queue/index.ts
@@ -1,7 +1,9 @@
 import { startQueue } from './boss';
+import { registerConceptGraphExtractWorker } from './jobs/graph-extraction';
 import { registerMaterialIngestWorker } from './worker';
 
 export * from './boss';
+export * from './jobs/graph-extraction';
 export * from './worker';
 
 let isInitialized = false;
@@ -14,6 +16,7 @@ export async function initQueueWorker(): Promise<void> {
   const boss = await startQueue();
   if (boss) {
     await registerMaterialIngestWorker(boss);
+    await registerConceptGraphExtractWorker(boss);
     isInitialized = true;
   }
 }

--- a/lib/queue/jobs/graph-extraction.test.ts
+++ b/lib/queue/jobs/graph-extraction.test.ts
@@ -1,6 +1,8 @@
 import type { PgBoss } from 'pg-boss';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  cleanupMaterialExtractedGraph,
+  getActiveProjectConceptNames,
   getKnowledgeComponentsByProjectId,
   insertExercises,
   insertKnowledgeDependencies,
@@ -24,6 +26,8 @@ vi.mock('@/lib/db/queries/knowledge', () => ({
   insertKnowledgeDependencies: vi.fn(),
   insertExercises: vi.fn(),
   getKnowledgeComponentsByProjectId: vi.fn(),
+  getActiveProjectConceptNames: vi.fn(),
+  cleanupMaterialExtractedGraph: vi.fn(),
 }));
 
 vi.mock('ai', async (importOriginal) => {
@@ -58,9 +62,13 @@ describe('Concept Graph Extraction Worker Job', () => {
   const mockInsertKd = vi.mocked(insertKnowledgeDependencies);
   const mockInsertExercises = vi.mocked(insertExercises);
   const mockGetKcsByProjectId = vi.mocked(getKnowledgeComponentsByProjectId);
+  const mockGetActiveProjectConceptNames = vi.mocked(getActiveProjectConceptNames);
+  const mockCleanupMaterialExtractedGraph = vi.mocked(cleanupMaterialExtractedGraph);
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetActiveProjectConceptNames.mockResolvedValue([]);
+    mockCleanupMaterialExtractedGraph.mockResolvedValue(undefined);
   });
 
   it('stitches chunks, extracts concepts/prereqs via generateObject, and updates status to ready', async () => {
@@ -547,5 +555,272 @@ describe('Concept Graph Extraction Worker Job', () => {
     await registerConceptGraphExtractWorker(mockBoss as unknown as PgBoss);
 
     expect(mockBoss.work).toHaveBeenCalledWith('concept-graph-extract', expect.any(Function));
+  });
+
+  it('atomically cleans up exercises and material-attributed dependencies before inserting fresh batches on re-extraction', async () => {
+    const { generateObject } = await import('ai');
+    const mockGenerateObject = vi.mocked(generateObject);
+
+    mockGetMaterialById.mockResolvedValueOnce({
+      id: 'mat-reextract',
+      projectId: 'proj-1',
+      userId: 'user-1',
+      title: 'Operating Systems Re-extract',
+      filename: 'os.md',
+      fileType: 'text/markdown',
+      fileSize: 100,
+      storagePath: 'proj-1/os.md',
+      status: 'ready',
+      errorMessage: null,
+      metadata: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    mockGetMaterialChunks.mockResolvedValueOnce([
+      {
+        id: 'chunk-1',
+        materialId: 'mat-reextract',
+        projectId: 'proj-1',
+        userId: 'user-1',
+        chunkIndex: 0,
+        content: 'Processes and Threads',
+        tokenCount: 50,
+        embedding: null,
+        metadata: { pageNumber: 1 },
+        createdAt: new Date(),
+      },
+    ]);
+
+    mockGenerateObject.mockResolvedValueOnce({
+      object: {
+        concepts: [{ name: 'Process', pacerCategory: 'conceptual', bloomLevel: 2, aliases: [] }],
+        prerequisites: [],
+        exercises: [],
+      },
+    } as never);
+
+    mockUpsertKc.mockResolvedValueOnce([]);
+
+    await processGraphExtraction({
+      projectId: 'proj-1',
+      userId: 'user-1',
+      materialIds: ['mat-reextract'],
+    });
+
+    // Verify cleanup was invoked before generating object / inserting new records
+    expect(mockCleanupMaterialExtractedGraph).toHaveBeenCalledTimes(1);
+    expect(mockCleanupMaterialExtractedGraph).toHaveBeenCalledWith({
+      materialId: 'mat-reextract',
+      projectId: 'proj-1',
+    });
+  });
+
+  it('injects up to 500 existing active project concepts into extraction prompt for vocabulary grounding', async () => {
+    const { generateObject } = await import('ai');
+    const mockGenerateObject = vi.mocked(generateObject);
+
+    mockGetMaterialById.mockResolvedValueOnce({
+      id: 'mat-vocab',
+      projectId: 'proj-1',
+      userId: 'user-1',
+      title: 'Graph Algorithms',
+      filename: 'graphs.md',
+      fileType: 'text/markdown',
+      fileSize: 100,
+      storagePath: 'proj-1/graphs.md',
+      status: 'ready',
+      errorMessage: null,
+      metadata: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    mockGetMaterialChunks.mockResolvedValueOnce([
+      {
+        id: 'chunk-1',
+        materialId: 'mat-vocab',
+        projectId: 'proj-1',
+        userId: 'user-1',
+        chunkIndex: 0,
+        content: 'Graph traversal algorithms.',
+        tokenCount: 20,
+        embedding: null,
+        metadata: { pageNumber: 1 },
+        createdAt: new Date(),
+      },
+    ]);
+
+    mockGetActiveProjectConceptNames.mockResolvedValueOnce([
+      'Depth First Search',
+      'Breadth First Search',
+      'Graph',
+    ]);
+
+    mockGenerateObject.mockResolvedValueOnce({
+      object: {
+        concepts: [
+          { name: 'Graph Traversal', pacerCategory: 'conceptual', bloomLevel: 2, aliases: [] },
+        ],
+        prerequisites: [],
+        exercises: [],
+      },
+    } as never);
+
+    mockUpsertKc.mockResolvedValueOnce([]);
+
+    await processGraphExtraction({
+      projectId: 'proj-1',
+      userId: 'user-1',
+      materialIds: ['mat-vocab'],
+    });
+
+    expect(mockGetActiveProjectConceptNames).toHaveBeenCalledWith({
+      projectId: 'proj-1',
+      limit: 500,
+    });
+
+    expect(mockGenerateObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringMatching(
+          /Depth First Search[\s\S]*Breadth First Search[\s\S]*Reuse existing concept names whenever the text discusses a concept already in the vocabulary\. Only create a new concept name if the concept is genuinely distinct\./,
+        ),
+      }),
+    );
+  });
+
+  it('processes multiple materials sequentially so downstream materials ground against concepts extracted from earlier materials', async () => {
+    const { generateObject } = await import('ai');
+    const mockGenerateObject = vi.mocked(generateObject);
+
+    const callOrder: string[] = [];
+
+    mockGetMaterialById.mockImplementation(({ id }: { id: string }) => {
+      callOrder.push(`getMaterialById:${id}`);
+      return Promise.resolve({
+        id,
+        projectId: 'proj-1',
+        userId: 'user-1',
+        title: `Doc ${id}`,
+        filename: `${id}.md`,
+        fileType: 'text/markdown',
+        fileSize: 100,
+        storagePath: `proj-1/${id}.md`,
+        status: 'ready',
+        errorMessage: null,
+        metadata: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+    });
+
+    mockGetMaterialChunks.mockImplementation(({ materialId }: { materialId: string }) => {
+      callOrder.push(`getChunks:${materialId}`);
+      return Promise.resolve([
+        {
+          id: `chunk-${materialId}`,
+          materialId,
+          projectId: 'proj-1',
+          userId: 'user-1',
+          chunkIndex: 0,
+          content: `Content for ${materialId}`,
+          tokenCount: 20,
+          embedding: null,
+          metadata: { pageNumber: 1 },
+          createdAt: new Date(),
+        },
+      ]);
+    });
+
+    mockCleanupMaterialExtractedGraph.mockImplementation(
+      ({ materialId }: { materialId: string }) => {
+        callOrder.push(`cleanup:${materialId}`);
+        return Promise.resolve();
+      },
+    );
+
+    // Material 1 extraction finds 'Linear Search'
+    // Material 2 should see 'Linear Search' in vocabulary
+    mockGetActiveProjectConceptNames
+      .mockResolvedValueOnce([]) // for mat-1
+      .mockResolvedValueOnce(['Linear Search']); // for mat-2 (reflects mat-1 concepts)
+
+    mockGenerateObject
+      .mockImplementationOnce(() => {
+        callOrder.push('generateObject:mat-1');
+        return Promise.resolve({
+          object: {
+            concepts: [
+              { name: 'Linear Search', pacerCategory: 'procedural', bloomLevel: 2, aliases: [] },
+            ],
+            prerequisites: [],
+            exercises: [],
+          },
+        } as never);
+      })
+      .mockImplementationOnce(() => {
+        callOrder.push('generateObject:mat-2');
+        return Promise.resolve({
+          object: {
+            concepts: [
+              { name: 'Binary Search', pacerCategory: 'procedural', bloomLevel: 3, aliases: [] },
+            ],
+            prerequisites: [],
+            exercises: [],
+          },
+        } as never);
+      });
+
+    mockUpsertKc.mockImplementation((kcs) => {
+      callOrder.push(`upsertKc:${kcs[0]?.name}`);
+      return Promise.resolve([
+        {
+          id: `kc-${kcs[0]?.slug}`,
+          projectId: 'proj-1',
+          userId: 'user-1',
+          slug: kcs[0]?.slug ?? '',
+          name: kcs[0]?.name ?? '',
+          pacerCategory: 'procedural',
+          bloomLevel: 2,
+          aliases: [],
+          embedding: null,
+          sourceMaterialId: 'mat-1',
+          status: 'active',
+          orderIndex: 0,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+    });
+
+    const result = await processGraphExtraction({
+      projectId: 'proj-1',
+      userId: 'user-1',
+      materialIds: ['mat-1', 'mat-2'],
+    });
+
+    expect(result.processedCount).toBe(2);
+
+    // Verify sequential execution order
+    expect(callOrder).toEqual([
+      'getMaterialById:mat-1',
+      'cleanup:mat-1',
+      'getChunks:mat-1',
+      'generateObject:mat-1',
+      'upsertKc:Linear Search',
+      'getMaterialById:mat-2',
+      'cleanup:mat-2',
+      'getChunks:mat-2',
+      'generateObject:mat-2',
+      'upsertKc:Binary Search',
+    ]);
+
+    // Verify mat-2's prompt included Linear Search
+    expect(mockGenerateObject).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        prompt: expect.stringContaining('Linear Search'),
+      }),
+    );
   });
 });

--- a/lib/queue/jobs/graph-extraction.test.ts
+++ b/lib/queue/jobs/graph-extraction.test.ts
@@ -1,0 +1,341 @@
+import type { PgBoss } from 'pg-boss';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { insertKnowledgeDependencies, upsertKnowledgeComponents } from '@/lib/db/queries/knowledge';
+import {
+  getMaterialById,
+  getMaterialChunksByMaterialId,
+  updateMaterialStatus,
+} from '@/lib/db/queries/material';
+import { processGraphExtraction, registerConceptGraphExtractWorker } from './graph-extraction';
+
+vi.mock('@/lib/db/queries/material', () => ({
+  getMaterialById: vi.fn(),
+  getMaterialChunksByMaterialId: vi.fn(),
+  updateMaterialStatus: vi.fn(),
+}));
+
+vi.mock('@/lib/db/queries/knowledge', () => ({
+  upsertKnowledgeComponents: vi.fn(),
+  insertKnowledgeDependencies: vi.fn(),
+}));
+
+vi.mock('ai', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('ai')>();
+  return {
+    ...actual,
+    generateObject: vi.fn(),
+  };
+});
+
+type WorkHandler = (jobs: Array<{ id: string; data: unknown }>) => Promise<void>;
+
+function createMockBoss() {
+  let capturedHandler: WorkHandler | null = null;
+  return {
+    work: vi.fn().mockImplementation((_queue: string, handler: WorkHandler) => {
+      capturedHandler = handler;
+      return Promise.resolve();
+    }),
+    getHandler: (): WorkHandler => {
+      if (!capturedHandler) throw new Error('Handler not registered');
+      return capturedHandler;
+    },
+  };
+}
+
+describe('Concept Graph Extraction Worker Job', () => {
+  const mockGetMaterialById = vi.mocked(getMaterialById);
+  const mockGetMaterialChunks = vi.mocked(getMaterialChunksByMaterialId);
+  const mockUpdateMaterialStatus = vi.mocked(updateMaterialStatus);
+  const mockUpsertKc = vi.mocked(upsertKnowledgeComponents);
+  const mockInsertKd = vi.mocked(insertKnowledgeDependencies);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('stitches chunks, extracts concepts/prereqs via generateObject, and updates status to ready', async () => {
+    const { generateObject } = await import('ai');
+    const mockGenerateObject = vi.mocked(generateObject);
+
+    mockGetMaterialById.mockResolvedValueOnce({
+      id: 'mat-1',
+      projectId: 'proj-1',
+      userId: 'user-1',
+      title: 'Operating Systems',
+      filename: 'os.md',
+      fileType: 'text/markdown',
+      fileSize: 100,
+      storagePath: 'proj-1/os.md',
+      status: 'ready',
+      errorMessage: null,
+      metadata: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    mockGetMaterialChunks.mockResolvedValueOnce([
+      {
+        id: 'chunk-1',
+        materialId: 'mat-1',
+        projectId: 'proj-1',
+        userId: 'user-1',
+        chunkIndex: 0,
+        content: '# Processes and Threads\nA process is an executing program.',
+        tokenCount: 50,
+        embedding: null,
+        metadata: { pageNumber: 1 },
+        createdAt: new Date(),
+      },
+      {
+        id: 'chunk-2',
+        materialId: 'mat-1',
+        projectId: 'proj-1',
+        userId: 'user-1',
+        chunkIndex: 1,
+        content: 'Threads share memory space within a process.',
+        tokenCount: 40,
+        embedding: null,
+        metadata: { pageNumber: 1 },
+        createdAt: new Date(),
+      },
+    ]);
+
+    mockGenerateObject.mockResolvedValueOnce({
+      object: {
+        concepts: [
+          {
+            name: 'Process',
+            pacerCategory: 'conceptual',
+            bloomLevel: 2,
+            aliases: ['OS Process'],
+          },
+          {
+            name: 'Thread',
+            pacerCategory: 'conceptual',
+            bloomLevel: 3,
+            aliases: ['Lightweight Process'],
+          },
+          {
+            name: 'Self Loop Test',
+            pacerCategory: 'procedural',
+            bloomLevel: 2,
+            aliases: [],
+          },
+        ],
+        prerequisites: [
+          {
+            sourceName: 'Process',
+            targetName: 'Thread',
+            relationshipType: 'prerequisite',
+            reasoning: 'Threads exist inside a process',
+          },
+          {
+            sourceName: 'Self Loop Test',
+            targetName: 'Self Loop Test',
+            relationshipType: 'prerequisite',
+            reasoning: 'Self loop to drop',
+          },
+          {
+            sourceName: 'Process',
+            targetName: 'Non Existent Concept',
+            relationshipType: 'prerequisite',
+            reasoning: 'Dangling target to drop',
+          },
+        ],
+      },
+    } as never);
+
+    mockUpsertKc.mockResolvedValueOnce([
+      {
+        id: 'kc-process-id',
+        projectId: 'proj-1',
+        userId: 'user-1',
+        slug: 'process',
+        name: 'Process',
+        pacerCategory: 'conceptual',
+        bloomLevel: 2,
+        aliases: ['OS Process'],
+        embedding: null,
+        sourceMaterialId: 'mat-1',
+        status: 'active',
+        orderIndex: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: 'kc-thread-id',
+        projectId: 'proj-1',
+        userId: 'user-1',
+        slug: 'thread',
+        name: 'Thread',
+        pacerCategory: 'conceptual',
+        bloomLevel: 3,
+        aliases: ['Lightweight Process'],
+        embedding: null,
+        sourceMaterialId: 'mat-1',
+        status: 'active',
+        orderIndex: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: 'kc-selfloop-id',
+        projectId: 'proj-1',
+        userId: 'user-1',
+        slug: 'self-loop-test',
+        name: 'Self Loop Test',
+        pacerCategory: 'procedural',
+        bloomLevel: 2,
+        aliases: [],
+        embedding: null,
+        sourceMaterialId: 'mat-1',
+        status: 'active',
+        orderIndex: 2,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+
+    mockInsertKd.mockResolvedValueOnce([]);
+
+    const result = await processGraphExtraction({
+      projectId: 'proj-1',
+      userId: 'user-1',
+      materialIds: ['mat-1'],
+    });
+
+    expect(result.processedCount).toBe(1);
+    expect(result.kcCount).toBe(3);
+
+    // Verify status transition: first 'extracting'
+    expect(mockUpdateMaterialStatus).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        id: 'mat-1',
+        status: 'ready', // Material status preserved!
+        metadata: expect.objectContaining({
+          graphExtraction: expect.objectContaining({
+            status: 'extracting',
+          }),
+        }),
+      }),
+    );
+
+    // Verify AI SDK call with strict prompt and schema
+    expect(mockGenerateObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining('# Processes and Threads'),
+      }),
+    );
+
+    // Verify KCs upserted with deterministic slugs
+    expect(mockUpsertKc).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          slug: 'process',
+          name: 'Process',
+          sourceMaterialId: 'mat-1',
+        }),
+        expect.objectContaining({
+          slug: 'thread',
+          name: 'Thread',
+          sourceMaterialId: 'mat-1',
+        }),
+      ]),
+    );
+
+    // Verify KDs inserted with resolved IDs, self-loop and dangling dropped
+    expect(mockInsertKd).toHaveBeenCalledWith([
+      expect.objectContaining({
+        sourceKcId: 'kc-process-id',
+        targetKcId: 'kc-thread-id',
+        relationshipType: 'prerequisite',
+        sourceMaterialId: 'mat-1',
+      }),
+    ]);
+
+    // Verify final status update to 'ready' with kcCount and completedAt
+    expect(mockUpdateMaterialStatus).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        id: 'mat-1',
+        status: 'ready', // Material status preserved
+        metadata: expect.objectContaining({
+          graphExtraction: expect.objectContaining({
+            status: 'ready',
+            kcCount: 3,
+            completedAt: expect.any(String),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('on failure, updates graphExtraction.status to failed while preserving material.status as ready', async () => {
+    const { generateObject } = await import('ai');
+    const mockGenerateObject = vi.mocked(generateObject);
+
+    mockGetMaterialById.mockResolvedValueOnce({
+      id: 'mat-err',
+      projectId: 'proj-1',
+      userId: 'user-1',
+      title: 'Faulty Doc',
+      filename: 'faulty.md',
+      fileType: 'text/markdown',
+      fileSize: 100,
+      storagePath: 'proj-1/faulty.md',
+      status: 'ready',
+      errorMessage: null,
+      metadata: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    mockGetMaterialChunks.mockResolvedValueOnce([
+      {
+        id: 'c-1',
+        materialId: 'mat-err',
+        projectId: 'proj-1',
+        userId: 'user-1',
+        chunkIndex: 0,
+        content: 'Faulty content',
+        tokenCount: 10,
+        embedding: null,
+        metadata: {},
+        createdAt: new Date(),
+      },
+    ]);
+
+    mockGenerateObject.mockRejectedValueOnce(new Error('AI rate limit exhausted'));
+
+    await expect(
+      processGraphExtraction({
+        projectId: 'proj-1',
+        userId: 'user-1',
+        materialIds: ['mat-err'],
+      }),
+    ).rejects.toThrow('AI rate limit exhausted');
+
+    // Verify that graphExtraction is marked as failed, but material.status remains 'ready'
+    expect(mockUpdateMaterialStatus).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        id: 'mat-err',
+        status: 'ready',
+        metadata: expect.objectContaining({
+          graphExtraction: expect.objectContaining({
+            status: 'failed',
+            error: 'AI rate limit exhausted',
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('registerConceptGraphExtractWorker registers worker on concept-graph-extract queue', async () => {
+    const mockBoss = createMockBoss();
+
+    await registerConceptGraphExtractWorker(mockBoss as unknown as PgBoss);
+
+    expect(mockBoss.work).toHaveBeenCalledWith('concept-graph-extract', expect.any(Function));
+  });
+});

--- a/lib/queue/jobs/graph-extraction.test.ts
+++ b/lib/queue/jobs/graph-extraction.test.ts
@@ -1,6 +1,11 @@
 import type { PgBoss } from 'pg-boss';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { insertKnowledgeDependencies, upsertKnowledgeComponents } from '@/lib/db/queries/knowledge';
+import {
+  getKnowledgeComponentsByProjectId,
+  insertExercises,
+  insertKnowledgeDependencies,
+  upsertKnowledgeComponents,
+} from '@/lib/db/queries/knowledge';
 import {
   getMaterialById,
   getMaterialChunksByMaterialId,
@@ -17,6 +22,8 @@ vi.mock('@/lib/db/queries/material', () => ({
 vi.mock('@/lib/db/queries/knowledge', () => ({
   upsertKnowledgeComponents: vi.fn(),
   insertKnowledgeDependencies: vi.fn(),
+  insertExercises: vi.fn(),
+  getKnowledgeComponentsByProjectId: vi.fn(),
 }));
 
 vi.mock('ai', async (importOriginal) => {
@@ -49,6 +56,8 @@ describe('Concept Graph Extraction Worker Job', () => {
   const mockUpdateMaterialStatus = vi.mocked(updateMaterialStatus);
   const mockUpsertKc = vi.mocked(upsertKnowledgeComponents);
   const mockInsertKd = vi.mocked(insertKnowledgeDependencies);
+  const mockInsertExercises = vi.mocked(insertExercises);
+  const mockGetKcsByProjectId = vi.mocked(getKnowledgeComponentsByProjectId);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -325,6 +334,207 @@ describe('Concept Graph Extraction Worker Job', () => {
           graphExtraction: expect.objectContaining({
             status: 'failed',
             error: 'AI rate limit exhausted',
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('extracts, links, and persists practice exercises anchoring to page numbers and tracks exerciseCount', async () => {
+    const { generateObject } = await import('ai');
+    const mockGenerateObject = vi.mocked(generateObject);
+
+    mockGetMaterialById.mockResolvedValueOnce({
+      id: 'mat-exercises',
+      projectId: 'proj-1',
+      userId: 'user-1',
+      title: 'Math Course',
+      filename: 'math.pdf',
+      fileType: 'application/pdf',
+      fileSize: 200,
+      storagePath: 'proj-1/math.pdf',
+      status: 'ready',
+      errorMessage: null,
+      metadata: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    mockGetMaterialChunks.mockResolvedValueOnce([
+      {
+        id: 'chunk-1',
+        materialId: 'mat-exercises',
+        projectId: 'proj-1',
+        userId: 'user-1',
+        chunkIndex: 0,
+        content: '# Chapter 1: Limits and Derivatives\nProblem 1.1: Calculate limit.',
+        tokenCount: 50,
+        embedding: null,
+        metadata: { pageNumber: 4 },
+        createdAt: new Date(),
+      },
+    ]);
+
+    mockGenerateObject.mockResolvedValueOnce({
+      object: {
+        concepts: [
+          {
+            name: 'Derivatives',
+            pacerCategory: 'conceptual',
+            bloomLevel: 2,
+            aliases: [],
+          },
+        ],
+        prerequisites: [],
+        exercises: [
+          {
+            pageNumber: 4,
+            title: 'Problem 1.1',
+            prompt: 'Compute limit as x -> 0 of sin(x)/x',
+            solution: '1',
+            questionType: 'calculation',
+            difficulty: 2,
+            targetConceptName: 'Limits', // matches existing project KC
+          },
+          {
+            pageNumber: 5,
+            title: 'Problem 1.2',
+            prompt: 'Explain derivative definition',
+            solution: undefined,
+            questionType: 'conceptual',
+            difficulty: 3,
+            targetConceptName: 'Derivatives', // matches active batch KC
+          },
+          {
+            pageNumber: 5,
+            title: 'Problem 1.3',
+            prompt: 'Dangling problem',
+            solution: undefined,
+            questionType: 'multiple_choice',
+            difficulty: 1,
+            targetConceptName: 'Unresolved Concept', // dangling, should be discarded
+          },
+        ],
+      },
+    } as never);
+
+    mockUpsertKc.mockResolvedValueOnce([
+      {
+        id: 'kc-derivatives',
+        projectId: 'proj-1',
+        userId: 'user-1',
+        slug: 'derivatives',
+        name: 'Derivatives',
+        pacerCategory: 'conceptual',
+        bloomLevel: 2,
+        aliases: [],
+        embedding: null,
+        sourceMaterialId: 'mat-exercises',
+        status: 'active',
+        orderIndex: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+
+    mockGetKcsByProjectId.mockResolvedValueOnce([
+      {
+        id: 'kc-limits',
+        projectId: 'proj-1',
+        userId: 'user-1',
+        slug: 'limits',
+        name: 'Limits',
+        pacerCategory: 'conceptual',
+        bloomLevel: 2,
+        aliases: [],
+        embedding: null,
+        sourceMaterialId: null,
+        status: 'active',
+        orderIndex: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+
+    mockInsertKd.mockResolvedValueOnce([]);
+    mockInsertExercises.mockResolvedValueOnce([
+      {
+        id: 'ex-1',
+        projectId: 'proj-1',
+        userId: 'user-1',
+        materialId: 'mat-exercises',
+        kcId: 'kc-limits',
+        pageNumber: 4,
+        title: 'Problem 1.1',
+        prompt: 'Compute limit as x -> 0 of sin(x)/x',
+        solution: '1',
+        questionType: 'calculation',
+        difficulty: 2,
+        createdAt: new Date(),
+      },
+      {
+        id: 'ex-2',
+        projectId: 'proj-1',
+        userId: 'user-1',
+        materialId: 'mat-exercises',
+        kcId: 'kc-derivatives',
+        pageNumber: 5,
+        title: 'Problem 1.2',
+        prompt: 'Explain derivative definition',
+        solution: null,
+        questionType: 'conceptual',
+        difficulty: 3,
+        createdAt: new Date(),
+      },
+    ]);
+
+    const result = await processGraphExtraction({
+      projectId: 'proj-1',
+      userId: 'user-1',
+      materialIds: ['mat-exercises'],
+    });
+
+    expect(result.processedCount).toBe(1);
+    expect(result.kcCount).toBe(1);
+    expect(result.exerciseCount).toBe(2);
+
+    // Verify insertExercises was called with resolved KCs, anchored pageNumbers, and discarded dangling
+    expect(mockInsertExercises).toHaveBeenCalledWith([
+      expect.objectContaining({
+        projectId: 'proj-1',
+        userId: 'user-1',
+        materialId: 'mat-exercises',
+        kcId: 'kc-limits',
+        pageNumber: 4,
+        title: 'Problem 1.1',
+        prompt: 'Compute limit as x -> 0 of sin(x)/x',
+        solution: '1',
+        questionType: 'calculation',
+        difficulty: 2,
+      }),
+      expect.objectContaining({
+        projectId: 'proj-1',
+        userId: 'user-1',
+        materialId: 'mat-exercises',
+        kcId: 'kc-derivatives',
+        pageNumber: 5,
+        title: 'Problem 1.2',
+        prompt: 'Explain derivative definition',
+        solution: null,
+        questionType: 'conceptual',
+        difficulty: 3,
+      }),
+    ]);
+
+    // Verify material status update tracks exerciseCount alongside kcCount
+    expect(mockUpdateMaterialStatus).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        id: 'mat-exercises',
+        metadata: expect.objectContaining({
+          graphExtraction: expect.objectContaining({
+            status: 'ready',
+            kcCount: 1,
+            exerciseCount: 2,
           }),
         }),
       }),

--- a/lib/queue/jobs/graph-extraction.ts
+++ b/lib/queue/jobs/graph-extraction.ts
@@ -1,8 +1,10 @@
 import { generateObject, type LanguageModel } from 'ai';
 import type { PgBoss } from 'pg-boss';
-import { CONCEPT_GRAPH_EXTRACTION_PROMPT } from '@/lib/ai/prompts';
+import { buildConceptExtractionPrompt, CONCEPT_GRAPH_EXTRACTION_PROMPT } from '@/lib/ai/prompts';
 import { getLanguageModel } from '@/lib/ai/providers';
 import {
+  cleanupMaterialExtractedGraph,
+  getActiveProjectConceptNames,
   getKnowledgeComponentsByProjectId,
   insertExercises,
   insertKnowledgeDependencies,
@@ -147,16 +149,26 @@ async function extractMaterialBatches(
     return { kcCount: 0, exerciseCount: 0 };
   }
 
+  const existingVocabulary = await getActiveProjectConceptNames({
+    projectId: ctx.projectId,
+    limit: 500,
+  });
+
   const batches = sliceMaterialChunksIntoBatches(chunks);
   const distinctConceptSlugs = new Set<string>();
   let totalExerciseCount = 0;
 
   for (const batch of batches) {
+    const prompt = buildConceptExtractionPrompt({
+      content: batch.content,
+      existingVocabulary,
+    });
+
     const result = await generateObject({
       model: ctx.model,
       schema: conceptExtractionSchema,
       system: CONCEPT_GRAPH_EXTRACTION_PROMPT,
-      prompt: `Extract knowledge concepts, prerequisite dependencies, and practice exercises/problems from the following educational material:\n\n${batch.content}`,
+      prompt,
     });
 
     const sanitized = sanitizeExtractedGraph(result.object);
@@ -219,6 +231,11 @@ async function processSingleMaterial(
   }
 
   await setExtractionStatus(material, 'extracting');
+
+  await cleanupMaterialExtractedGraph({
+    materialId: ctx.materialId,
+    projectId: ctx.projectId,
+  });
 
   try {
     const counts = await extractMaterialBatches(ctx);

--- a/lib/queue/jobs/graph-extraction.ts
+++ b/lib/queue/jobs/graph-extraction.ts
@@ -1,0 +1,242 @@
+import { generateObject, type LanguageModel } from 'ai';
+import type { PgBoss } from 'pg-boss';
+import { CONCEPT_GRAPH_EXTRACTION_PROMPT } from '@/lib/ai/prompts';
+import { getLanguageModel } from '@/lib/ai/providers';
+import { insertKnowledgeDependencies, upsertKnowledgeComponents } from '@/lib/db/queries/knowledge';
+import {
+  getMaterialById,
+  getMaterialChunksByMaterialId,
+  updateMaterialStatus,
+} from '@/lib/db/queries/material';
+import type { Material, NewKnowledgeComponent, NewKnowledgeDependency } from '@/lib/db/schema';
+import {
+  conceptExtractionSchema,
+  type SanitizedExtractionResult,
+  sanitizeExtractedGraph,
+  sliceMaterialChunksIntoBatches,
+  updateMaterialGraphExtractionMetadata,
+} from '@/lib/materials/concept-extraction';
+import { CONCEPT_GRAPH_EXTRACT_QUEUE, type ConceptGraphExtractJobData } from '@/lib/queue/boss';
+
+export type ExtractionContext = {
+  materialId: string;
+  projectId: string;
+  userId: string;
+  model: LanguageModel;
+};
+
+export type ProcessGraphExtractionOptions = {
+  model?: LanguageModel;
+  isFinalAttempt?: boolean;
+};
+
+export type ProcessGraphExtractionResult = {
+  processedCount: number;
+  kcCount: number;
+};
+
+async function persistExtractedGraph(
+  ctx: ExtractionContext,
+  sanitized: SanitizedExtractionResult,
+): Promise<void> {
+  if (sanitized.concepts.length === 0) {
+    return;
+  }
+
+  const newKcs: NewKnowledgeComponent[] = sanitized.concepts.map((c, idx) => ({
+    projectId: ctx.projectId,
+    userId: ctx.userId,
+    slug: c.slug,
+    name: c.name,
+    pacerCategory: c.pacerCategory,
+    bloomLevel: c.bloomLevel,
+    aliases: c.aliases,
+    sourceMaterialId: ctx.materialId,
+    status: 'active',
+    orderIndex: idx,
+  }));
+
+  const upsertedKcs = await upsertKnowledgeComponents(newKcs);
+  const slugToId = new Map(upsertedKcs.map((k) => [k.slug, k.id]));
+
+  const newKds: NewKnowledgeDependency[] = [];
+  for (const p of sanitized.prerequisites) {
+    const sourceKcId = slugToId.get(p.sourceSlug);
+    const targetKcId = slugToId.get(p.targetSlug);
+    if (sourceKcId && targetKcId) {
+      newKds.push({
+        projectId: ctx.projectId,
+        sourceKcId,
+        targetKcId,
+        relationshipType: p.relationshipType,
+        reasoning: p.reasoning,
+        sourceMaterialId: ctx.materialId,
+        isTransitive: false,
+      });
+    }
+  }
+
+  if (newKds.length > 0) {
+    await insertKnowledgeDependencies(newKds);
+  }
+}
+
+async function extractMaterialBatches(ctx: ExtractionContext): Promise<number> {
+  const chunks = await getMaterialChunksByMaterialId({ materialId: ctx.materialId });
+  if (chunks.length === 0) {
+    return 0;
+  }
+
+  const batches = sliceMaterialChunksIntoBatches(chunks);
+  const distinctConceptSlugs = new Set<string>();
+
+  for (const batch of batches) {
+    const result = await generateObject({
+      model: ctx.model,
+      schema: conceptExtractionSchema,
+      system: CONCEPT_GRAPH_EXTRACTION_PROMPT,
+      prompt: `Extract knowledge concepts and prerequisite dependencies from the following educational material:\n\n${batch.content}`,
+    });
+
+    const sanitized = sanitizeExtractedGraph(result.object);
+    for (const c of sanitized.concepts) {
+      distinctConceptSlugs.add(c.slug);
+    }
+
+    await persistExtractedGraph(ctx, sanitized);
+  }
+
+  return distinctConceptSlugs.size;
+}
+
+async function setExtractionStatus(
+  material: Material,
+  status: 'extracting' | 'ready' | 'failed',
+  details: { kcCount?: number; error?: string } = {},
+): Promise<void> {
+  const now = new Date().toISOString();
+  const update: Record<string, unknown> = { status };
+
+  if (status === 'extracting') {
+    update.startedAt = now;
+  } else if (status === 'ready') {
+    update.completedAt = now;
+    update.kcCount = details.kcCount ?? 0;
+  } else if (status === 'failed') {
+    update.completedAt = now;
+    update.error = details.error;
+  }
+
+  const metadata = updateMaterialGraphExtractionMetadata(
+    material.metadata as Record<string, unknown>,
+    update,
+  );
+
+  await updateMaterialStatus({
+    id: material.id,
+    status: material.status, // preserve existing material status
+    metadata,
+  });
+}
+
+async function processSingleMaterial(
+  ctx: ExtractionContext,
+  isFinalAttempt: boolean,
+): Promise<number> {
+  const material = await getMaterialById({
+    id: ctx.materialId,
+    projectId: ctx.projectId,
+    userId: ctx.userId,
+  });
+  if (!material) {
+    return 0;
+  }
+
+  await setExtractionStatus(material, 'extracting');
+
+  try {
+    const kcCount = await extractMaterialBatches(ctx);
+    await setExtractionStatus(material, 'ready', { kcCount });
+    return kcCount;
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : 'Concept graph extraction failed';
+    if (isFinalAttempt) {
+      try {
+        await setExtractionStatus(material, 'failed', { error: errorMessage });
+      } catch (metaErr) {
+        console.error('Failed to record extraction error on material:', metaErr);
+      }
+    }
+    throw err;
+  }
+}
+
+export async function processGraphExtraction(
+  data: ConceptGraphExtractJobData,
+  options: ProcessGraphExtractionOptions = {},
+): Promise<ProcessGraphExtractionResult> {
+  const { projectId, userId, materialIds } = data;
+  const model = options.model ?? getLanguageModel({ modelId: 'gemini-3.7-flash' });
+  const isFinalAttempt = options.isFinalAttempt ?? true;
+
+  let processedCount = 0;
+  let totalKcCount = 0;
+
+  for (const materialId of materialIds) {
+    const kcCount = await processSingleMaterial(
+      {
+        materialId,
+        projectId,
+        userId,
+        model,
+      },
+      isFinalAttempt,
+    );
+    processedCount++;
+    totalKcCount += kcCount;
+  }
+
+  return {
+    processedCount,
+    kcCount: totalKcCount,
+  };
+}
+
+function getJobRetryInfo(job: unknown): { retryCount: number; isFinalAttempt: boolean } {
+  const jobRecord = job as Record<string, unknown>;
+  const retryCount =
+    typeof jobRecord.retryCount === 'number'
+      ? jobRecord.retryCount
+      : typeof jobRecord.retrycount === 'number'
+        ? jobRecord.retrycount
+        : 0;
+  const retryLimit =
+    typeof jobRecord.retryLimit === 'number'
+      ? jobRecord.retryLimit
+      : typeof jobRecord.retrylimit === 'number'
+        ? jobRecord.retrylimit
+        : 2;
+  return { retryCount, isFinalAttempt: retryCount >= retryLimit };
+}
+
+async function handleWorkerJob(job: {
+  id: string;
+  data: ConceptGraphExtractJobData;
+}): Promise<void> {
+  const { retryCount, isFinalAttempt } = getJobRetryInfo(job);
+  try {
+    await processGraphExtraction(job.data, { isFinalAttempt });
+  } catch (err) {
+    console.error(`Job ${job.id} failed (attempt ${retryCount + 1}):`, err);
+    throw err;
+  }
+}
+
+export async function registerConceptGraphExtractWorker(boss: PgBoss): Promise<void> {
+  await boss.work<ConceptGraphExtractJobData>(CONCEPT_GRAPH_EXTRACT_QUEUE, async (jobs) => {
+    const jobList = Array.isArray(jobs) ? jobs : [jobs];
+    for (const job of jobList) {
+      await handleWorkerJob(job);
+    }
+  });
+}

--- a/lib/queue/jobs/graph-extraction.ts
+++ b/lib/queue/jobs/graph-extraction.ts
@@ -2,15 +2,27 @@ import { generateObject, type LanguageModel } from 'ai';
 import type { PgBoss } from 'pg-boss';
 import { CONCEPT_GRAPH_EXTRACTION_PROMPT } from '@/lib/ai/prompts';
 import { getLanguageModel } from '@/lib/ai/providers';
-import { insertKnowledgeDependencies, upsertKnowledgeComponents } from '@/lib/db/queries/knowledge';
+import {
+  getKnowledgeComponentsByProjectId,
+  insertExercises,
+  insertKnowledgeDependencies,
+  upsertKnowledgeComponents,
+} from '@/lib/db/queries/knowledge';
 import {
   getMaterialById,
   getMaterialChunksByMaterialId,
   updateMaterialStatus,
 } from '@/lib/db/queries/material';
-import type { Material, NewKnowledgeComponent, NewKnowledgeDependency } from '@/lib/db/schema';
+import type {
+  KnowledgeComponent,
+  Material,
+  NewKnowledgeComponent,
+  NewKnowledgeDependency,
+} from '@/lib/db/schema';
 import {
   conceptExtractionSchema,
+  type KcIdentifier,
+  linkExercisesToKcs,
   type SanitizedExtractionResult,
   sanitizeExtractedGraph,
   sliceMaterialChunksIntoBatches,
@@ -33,14 +45,15 @@ export type ProcessGraphExtractionOptions = {
 export type ProcessGraphExtractionResult = {
   processedCount: number;
   kcCount: number;
+  exerciseCount: number;
 };
 
-async function persistExtractedGraph(
+async function persistKnowledgeGraph(
   ctx: ExtractionContext,
   sanitized: SanitizedExtractionResult,
-): Promise<void> {
+): Promise<KnowledgeComponent[]> {
   if (sanitized.concepts.length === 0) {
-    return;
+    return [];
   }
 
   const newKcs: NewKnowledgeComponent[] = sanitized.concepts.map((c, idx) => ({
@@ -79,23 +92,71 @@ async function persistExtractedGraph(
   if (newKds.length > 0) {
     await insertKnowledgeDependencies(newKds);
   }
+
+  return upsertedKcs;
 }
 
-async function extractMaterialBatches(ctx: ExtractionContext): Promise<number> {
+async function persistExtractedExercises(
+  ctx: ExtractionContext,
+  sanitized: SanitizedExtractionResult,
+  upsertedKcs: KnowledgeComponent[],
+): Promise<number> {
+  if (!sanitized.exercises || sanitized.exercises.length === 0) {
+    return 0;
+  }
+
+  const existingProjectKcs = await getKnowledgeComponentsByProjectId({
+    projectId: ctx.projectId,
+  });
+
+  const availableKcsMap = new Map<string, KcIdentifier>();
+  for (const kc of [...existingProjectKcs, ...upsertedKcs]) {
+    availableKcsMap.set(kc.id, { id: kc.id, name: kc.name, slug: kc.slug });
+  }
+
+  const linkedExercises = linkExercisesToKcs({
+    exercises: sanitized.exercises,
+    availableKcs: Array.from(availableKcsMap.values()),
+    projectId: ctx.projectId,
+    userId: ctx.userId,
+    materialId: ctx.materialId,
+  });
+
+  if (linkedExercises.length === 0) {
+    return 0;
+  }
+
+  const inserted = await insertExercises(linkedExercises);
+  return inserted.length;
+}
+
+async function persistExtractedGraph(
+  ctx: ExtractionContext,
+  sanitized: SanitizedExtractionResult,
+): Promise<{ exerciseCount: number }> {
+  const upsertedKcs = await persistKnowledgeGraph(ctx, sanitized);
+  const exerciseCount = await persistExtractedExercises(ctx, sanitized, upsertedKcs);
+  return { exerciseCount };
+}
+
+async function extractMaterialBatches(
+  ctx: ExtractionContext,
+): Promise<{ kcCount: number; exerciseCount: number }> {
   const chunks = await getMaterialChunksByMaterialId({ materialId: ctx.materialId });
   if (chunks.length === 0) {
-    return 0;
+    return { kcCount: 0, exerciseCount: 0 };
   }
 
   const batches = sliceMaterialChunksIntoBatches(chunks);
   const distinctConceptSlugs = new Set<string>();
+  let totalExerciseCount = 0;
 
   for (const batch of batches) {
     const result = await generateObject({
       model: ctx.model,
       schema: conceptExtractionSchema,
       system: CONCEPT_GRAPH_EXTRACTION_PROMPT,
-      prompt: `Extract knowledge concepts and prerequisite dependencies from the following educational material:\n\n${batch.content}`,
+      prompt: `Extract knowledge concepts, prerequisite dependencies, and practice exercises/problems from the following educational material:\n\n${batch.content}`,
     });
 
     const sanitized = sanitizeExtractedGraph(result.object);
@@ -103,16 +164,20 @@ async function extractMaterialBatches(ctx: ExtractionContext): Promise<number> {
       distinctConceptSlugs.add(c.slug);
     }
 
-    await persistExtractedGraph(ctx, sanitized);
+    const persistResult = await persistExtractedGraph(ctx, sanitized);
+    totalExerciseCount += persistResult.exerciseCount;
   }
 
-  return distinctConceptSlugs.size;
+  return {
+    kcCount: distinctConceptSlugs.size,
+    exerciseCount: totalExerciseCount,
+  };
 }
 
 async function setExtractionStatus(
   material: Material,
   status: 'extracting' | 'ready' | 'failed',
-  details: { kcCount?: number; error?: string } = {},
+  details: { kcCount?: number; exerciseCount?: number; error?: string } = {},
 ): Promise<void> {
   const now = new Date().toISOString();
   const update: Record<string, unknown> = { status };
@@ -122,6 +187,7 @@ async function setExtractionStatus(
   } else if (status === 'ready') {
     update.completedAt = now;
     update.kcCount = details.kcCount ?? 0;
+    update.exerciseCount = details.exerciseCount ?? 0;
   } else if (status === 'failed') {
     update.completedAt = now;
     update.error = details.error;
@@ -142,22 +208,22 @@ async function setExtractionStatus(
 async function processSingleMaterial(
   ctx: ExtractionContext,
   isFinalAttempt: boolean,
-): Promise<number> {
+): Promise<{ kcCount: number; exerciseCount: number }> {
   const material = await getMaterialById({
     id: ctx.materialId,
     projectId: ctx.projectId,
     userId: ctx.userId,
   });
   if (!material) {
-    return 0;
+    return { kcCount: 0, exerciseCount: 0 };
   }
 
   await setExtractionStatus(material, 'extracting');
 
   try {
-    const kcCount = await extractMaterialBatches(ctx);
-    await setExtractionStatus(material, 'ready', { kcCount });
-    return kcCount;
+    const counts = await extractMaterialBatches(ctx);
+    await setExtractionStatus(material, 'ready', counts);
+    return counts;
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : 'Concept graph extraction failed';
     if (isFinalAttempt) {
@@ -181,9 +247,10 @@ export async function processGraphExtraction(
 
   let processedCount = 0;
   let totalKcCount = 0;
+  let totalExerciseCount = 0;
 
   for (const materialId of materialIds) {
-    const kcCount = await processSingleMaterial(
+    const counts = await processSingleMaterial(
       {
         materialId,
         projectId,
@@ -193,12 +260,14 @@ export async function processGraphExtraction(
       isFinalAttempt,
     );
     processedCount++;
-    totalKcCount += kcCount;
+    totalKcCount += counts.kcCount;
+    totalExerciseCount += counts.exerciseCount;
   }
 
   return {
     processedCount,
     kcCount: totalKcCount,
+    exerciseCount: totalExerciseCount,
   };
 }
 


### PR DESCRIPTION
## Summary

Consolidated implementation for epic `concept-graph-ingestion` (Stage 2.1 Part 2 — Pragmatic Concept Graph & Material Ingestion).
Resolves #117
Closes #118
Closes #119
Closes #120
Closes #121
Closes #122

## Changes

- **Single-Material Concept & Prerequisite Extraction (#118)**:
  - Lean relational schema (`knowledgeComponents`, `knowledgeDependencies`) with migrations, unique constraints, and foreign key cascades (`set null` on source material).
  - Background worker processing stored markdown chunks into 16k–32k token batches using `gemini-3.7-flash` via AI SDK `generateObject` with strict PACER and Bloom level classification.
  - Deterministic concept slugification, conflict resolution (`ON CONFLICT DO NOTHING`), and graph sanitization (dropping self-loops and dangling edges).
  - API endpoint `POST /api/projects/[id]/graph/extract` and sidebar material action menu & status badge ("Extracting Graph...").
- **Page-Anchored Practice Problem & Exercise Extraction (#119)**:
  - Relational schema for `exercises` with foreign key cascades to `projects`, `materials`, `knowledgeComponents`, and `authUsers`.
  - Batch Zod schema & prompt extension capturing `pageNumber`, `questionType`, `difficulty`, optional `title`/`prompt`, and nullable `solution`.
  - Automatic linking to extracted KCs, discarding dangling exercises, and material metadata tracking of `exerciseCount`.
- **Project-Wide Graph Synchronization & Idempotency (#120)**:
  - Sidebar "Sync Graph" button with client-side derived spinning/disabled state when jobs are active.
  - pg-boss queue dispatch with `singletonKey: 'project:' + projectId` debouncing.
  - Vocabulary grounding prompt injection (up to 500 active concepts) enforcing cross-material concept unification.
  - Concept upserts merging aliases via deduplicated JSONB set union and `GREATEST` Bloom level update.
  - Atomic re-extraction cleanup purging previous material exercises and attributed dependencies while preserving concept nodes and learner history.
- **Cycle-Guarded Concept Neighborhoods & Prerequisite Chains (#121)**:
  - `getGraphNeighborhood` supporting 1-hop and 2-hop expansions for direct prerequisites and unlocked concepts.
  - `getPrerequisiteChain` using recursive SQL CTE with cycle guard terminating safely under 25ms on cyclic/co-requisite graphs.
  - Dual-Output AI tools (`getGraphNeighborhoodTool`, `getPrerequisiteChainTool`) maintaining ≤15 token terse summaries for LLM history while providing rich client payloads.
- **Ready-to-Learn Frontier & Exercise Discovery (#122)**:
  - `getReadyToLearnFrontier` resolving unblocked concepts (or root concepts when no prior mastery records exist).
  - `getExercisesForKc` retrieving page-anchored exercises directly without join table overhead.
  - Dual-Output AI tool `getExercisesForKcTool` wired to chat streaming engine.

## Definition of Done

- [x] All acceptance criteria for #118 verified
- [x] All acceptance criteria for #119 verified
- [x] All acceptance criteria for #120 verified
- [x] All acceptance criteria for #121 verified
- [x] All acceptance criteria for #122 verified

## Verification

- [x] `pnpm check` passes (lint + typecheck + 53 test files / 475 unit & integration tests)
- [x] Subagent code reviews completed (Standards & Spec reviews passed on all tickets)